### PR TITLE
Update androlyze.py

### DIFF
--- a/androlyze.py
+++ b/androlyze.py
@@ -39,7 +39,7 @@ from androguard.decompiler.decompiler import *
 from androguard.core import androconf
 from androguard.util import read
 
-from IPython.frontend.terminal.embed import InteractiveShellEmbed
+from IPython.terminal.embed import InteractiveShellEmbed
 from IPython.config.loader import Config
 
 from cPickle import dumps, loads


### PR DESCRIPTION
Correct IPython InteractiveShellEmbed import to avoid the warning: "The top-level `frontend` package has been deprecated. All its subpackages have been moved to the top `IPython` level."
