### PR TITLE
Use getter for consistency

### DIFF
--- a/androguard/decompiler/dad/decompile.py
+++ b/androguard/decompiler/dad/decompile.py
@@ -185,7 +185,7 @@ class DvClass(object):
         self.access = util.get_access_class(access)
         self.prototype = prototype % (' '.join(self.access), self.name)
 
-        self.interfaces = dvclass.interfaces
+        self.interfaces = dvclass.get_interfaces()
         self.superclass = dvclass.get_superclassname()
 
         logger.info('Class : %s', self.name)


### PR DESCRIPTION
The JVM code contains lots of references to nonexistent functions, so presumably noone is using them, and if they did try to use them, it would just crash anyway.
