### PR TITLE
const/high16 opcode had wrong implementation

### DIFF
--- a/androguard/decompiler/dad/opcode_ins.py
+++ b/androguard/decompiler/dad/opcode_ins.py
@@ -258,8 +258,8 @@ def const(ins, vmap):
 # const/high16 vAA, #+BBBB0000 ( 8b, 16b )
 def consthigh16(ins, vmap):
     logger.debug('ConstHigh16 : %s', ins.get_output())
-    value = unpack('=f', '\x00\x00' + pack('=h', ins.BBBB))[0]
-    cst = Constant(value, 'I', ins.BBBB)
+    value = unpack('=f', pack('=i', ins.BBBB<<16))[0]
+    cst = Constant(value, 'I', ins.BBBB<<16)
     return assign_const(ins.AA, cst, vmap)
 
 


### PR DESCRIPTION
IMHO the value of the opcode must be shifted by 16bits because const/high16 puts the 2bytes of data into the high part of the 32bit register.
this should fix issue 136 on google issue tracker: https://code.google.com/p/androguard/issues/detail?id=136

unfortunately this fixes it only for DAD and not for the bytecode format. 
