### PR TITLE
changes on dad decomplier module

### DIFF
--- a/androguard/decompiler/dad/decompile.py
+++ b/androguard/decompiler/dad/decompile.py
@@ -283,6 +283,12 @@ class DvClass(object):
             source.append('package %s;\n' % self.package)
 
         superclass, prototype = self.superclass, self.prototype
+        if(prototype.find("$")>0): #by nkbai@163.com delete outer classname
+            prototype=prototype.strip();
+            spaceSplits=prototype.split(" ");
+            className=spaceSplits[-1]
+            spaceSplits[-1]=className[className.find('$')+1:]
+            prototype=' '.join(spaceSplits);
         if superclass is not None and superclass != 'Ljava/lang/Object;':
             superclass = superclass[1:-1].replace('/', '.')
             prototype += ' extends %s' % superclass

--- a/androguard/decompiler/dad/writer.py
+++ b/androguard/decompiler/dad/writer.py
@@ -146,6 +146,8 @@ class Writer(object):
             self.write_ext(('PROTOTYPE_ACCESS', '%s ' % ' '.join(acc)))
         if self.constructor:
             name = get_type(self.method.cls_name).split('.')[-1]
+            if(name.find('$')>=0): #by nkbai@163.com delete outer classname from constructor name
+                name=name[name.find('$')+1:];
             self.write(name)
             self.write_ext(('NAME_METHOD_PROTOTYPE', '%s' % name, self.method))
         else:


### PR DESCRIPTION
delete outer classname when generate java source
for example :
	for class declaration:
	public class OuterClassName$InnerClassName --> public class InnerClassName
	for constructor:
	public OuterClassName$InnerClassName()-->public InnerClassName()