### PR TITLE
fix a zipmodule wrong in androrisk.py

### DIFF
--- a/androrisk.py
+++ b/androrisk.py
@@ -56,7 +56,7 @@ def main(options, arguments):
     if options.input != None:
         ret_type = androconf.is_android( options.input )
         if ret_type == "APK":
-            a = apk.APK( options.input )
+            a = apk.APK( options.input ，zipmodule=2 )
             analyze_app( options.input, ri, a )
         elif ret_type == "DEX":
             analyze_dex( options.input, ri, read(options.input, binary=False) )


### PR DESCRIPTION
use zipmodule=2 in androrisk.py,fix the error:

  File "/usr/lib/python2.7/zipfile.py", line 373, in _decodeExtra
    tp, ln = unpack('<HH', extra[:4])
struct.error: unpack requires a string argument of length 4