### PR TITLE
Fix for is_android_raw in detecting *.apk files

### DIFF
--- a/androguard/core/androconf.py
+++ b/androguard/core/androconf.py
@@ -209,26 +209,25 @@ def is_android(filename):
 
     val = None
     with open(filename, "r") as fd:
-        f_bytes = fd.read(7)
+        f_bytes = fd.read()
         val = is_android_raw( f_bytes )
 
     return val
 
 def is_android_raw(raw):
     val = None
-    f_bytes = raw[:7]
 
-    if f_bytes[0:2] == "PK":
+    if raw[0:2] == "PK" or ('AndroidManifest.xml' in raw and 'META-INF/MANIFEST.MF' in raw):
         val = "APK"
-    elif f_bytes[0:3] == "dex":
+    elif raw[0:3] == "dex":
         val = "DEX"
-    elif f_bytes[0:3] == "dey":
+    elif raw[0:3] == "dey":
         val = "DEY"
-    elif f_bytes[0:7] == "\x7fELF\x01\x01\x01":
+    elif raw[0:7] == "\x7fELF\x01\x01\x01":
         val = "ELF"
-    elif f_bytes[0:4] == "\x03\x00\x08\x00":
+    elif raw[0:4] == "\x03\x00\x08\x00":
         val = "AXML"
-    elif f_bytes[0:4] == "\x02\x00\x0C\x00":
+    elif raw[0:4] == "\x02\x00\x0C\x00":
         val = "ARSC"
 
     return val

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -228,6 +228,24 @@ class APK(object):
         """
         return self.filename
 
+    def get_app_name(self):
+        """
+            Return the appname of the APK
+
+            :rtype: string
+        """        
+        app_elem = self.get_AndroidManifest().getElementsByTagName("application")[0]
+        app_name = app_elem.getAttribute("android:label")
+        if app_name.startswith("@"):
+            res_parser = self.get_android_resources()
+            app_name = ''
+            for package_name in res_parser.get_packages_names():
+                app_name = res_parser.get_string(package_name, 'app_name')
+                if app_name:
+                    app_name = app_name[1]
+                    break
+        return app_name
+
     def get_package(self):
         """
             Return the name of the package


### PR DESCRIPTION
The previous version of 'is_android_raw' is not able to detect some *.apk files in which the string 'PK' is not in the first block of 7 bytes and it's position is variable.

![apk_bytes](https://cloud.githubusercontent.com/assets/8762278/7113493/b0eebdd8-e1d4-11e4-9126-bfc6a21a3c79.png)

So, to correctly detect all *.apk files we need also to check some immutable resources which are absolutely present in their packages, such as 'AndroidManifest.xml' and 'META-INF/MANIFEST.MF'.