### PR TITLE
The original readsleb128 has two major bugs.

### DIFF
--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -214,7 +214,7 @@ def readsleb128(buff):
     result = 0
     shift = 0
 
-    while (True):
+    for x in range(0, 5):
        cur = ord( buff.read(1) )
        result |= (cur & 0x7f) << shift
        shift += 7

--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -211,31 +211,21 @@ def readuleb128p1(buff):
   return readuleb128( buff ) - 1
 
 def readsleb128(buff):
-    result = unpack( '=b', buff.read(1) )[0]
+    result = 0
+    shift = 0
 
-    if result <= 0x7f:
-        result = (result << 25)
-        if result > 0x7fffffff:
-            result = (0x7fffffff & result) - 0x80000000
-        result = result >> 25
-    else:
-        cur = unpack( '=b', buff.read(1) )[0]
-        result = (result & 0x7f) | ((cur & 0x7f) << 7)
-        if cur <= 0x7f:
-            result = (result << 18) >> 18
-        else:
-            cur = unpack( '=b', buff.read(1) )[0]
-            result |= (cur & 0x7f) << 14
-            if cur <= 0x7f:
-                result = (result << 11) >> 11
-            else:
-                cur = unpack( '=b', buff.read(1) )[0]
-                result |= (cur & 0x7f) << 21
-                if cur <= 0x7f:
-                    result = (result << 4) >> 4
-                else:
-                    cur = unpack( '=b', buff.read(1) )[0]
-                    result |= cur << 28
+    while (True):
+       cur = ord( buff.read(1) )
+       result |= (cur & 0x7f) << shift
+       shift += 7
+
+       if not cur & 0x80:
+          bit_left = max(32 - shift, 0)
+          result = result << bit_left
+          if result > 0x7fffffff:
+              result = (0x7fffffff & result) - 0x80000000
+          result = result >> bit_left
+          break
 
     return result
 


### PR DESCRIPTION
- 1. result = unpack( '=b', buff.read(1) )[0]
     if result <= 0x7f:
        ...
     Wont work with multi-bytes leb128, as the "result" will be read
     as signed value and in multi-bytes, the MSB of all but the last
     byte are all set to 1.

     Therefore the "result", which is read as the first byte of a
     leb128 will always be negative, hence this condition test will
     always be true. Which means, it really just reads one byte and
     stops there for every signed leb128.

- 2. result = (result << 18) >> 18
     ...

     This , which I believe is to extend the sign bit, won't work with
     negative number neither, as after bit operator, result could become
     positive from negative.

Tese case like this:
t = -624485
assert (t == dvm.readsleb128_1(bytecode.BuffHandle(dvm.writesleb128(t))))

Would show what happens.