### PR TITLE
Fix array length

### DIFF
--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -214,7 +214,7 @@ def readsleb128(buff):
     result = 0
     shift = 0
 
-    while (True):
+    for x in range(0, 5):
        cur = ord( buff.read(1) )
        result |= (cur & 0x7f) << shift
        shift += 7

--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -211,31 +211,21 @@ def readuleb128p1(buff):
   return readuleb128( buff ) - 1
 
 def readsleb128(buff):
-    result = unpack( '=b', buff.read(1) )[0]
+    result = 0
+    shift = 0
 
-    if result <= 0x7f:
-        result = (result << 25)
-        if result > 0x7fffffff:
-            result = (0x7fffffff & result) - 0x80000000
-        result = result >> 25
-    else:
-        cur = unpack( '=b', buff.read(1) )[0]
-        result = (result & 0x7f) | ((cur & 0x7f) << 7)
-        if cur <= 0x7f:
-            result = (result << 18) >> 18
-        else:
-            cur = unpack( '=b', buff.read(1) )[0]
-            result |= (cur & 0x7f) << 14
-            if cur <= 0x7f:
-                result = (result << 11) >> 11
-            else:
-                cur = unpack( '=b', buff.read(1) )[0]
-                result |= (cur & 0x7f) << 21
-                if cur <= 0x7f:
-                    result = (result << 4) >> 4
-                else:
-                    cur = unpack( '=b', buff.read(1) )[0]
-                    result |= cur << 28
+    while (True):
+       cur = ord( buff.read(1) )
+       result |= (cur & 0x7f) << shift
+       shift += 7
+
+       if not cur & 0x80:
+          bit_left = max(32 - shift, 0)
+          result = result << bit_left
+          if result > 0x7fffffff:
+              result = (0x7fffffff & result) - 0x80000000
+          result = result >> bit_left
+          break
 
     return result
 

--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -5671,7 +5671,7 @@ DALVIK_OPCODES_FORMAT = {
   0x1e : [Instruction11x, [ "monitor-exit" ] ],
   0x1f : [Instruction21c, [ "check-cast", KIND_TYPE ] ],
   0x20 : [Instruction22c, [ "instance-of", KIND_TYPE ] ],
-  0x21 : [Instruction12x, [ "array-length", KIND_TYPE ] ],
+  0x21 : [Instruction12x, [ "array-length" ] ],
   0x22 : [Instruction21c, [ "new-instance", KIND_TYPE ] ],
   0x23 : [Instruction22c, [ "new-array", KIND_TYPE ] ],
 


### PR DESCRIPTION
The array-length instruction has no type reference, hence removed.