### PR TITLE
Fix bug: wrong array length calculation in FillArray instruction.

### DIFF
--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -3937,7 +3937,11 @@ class FillArrayData(object):
         self.element_width = unpack("=H", buff[2:4])[0]
         self.size = unpack("=I", buff[4:8])[0]
 
-        self.data = buff[self.format_general_size:self.format_general_size + (self.size * self.element_width) + 1]
+        buf_len = self.size * self.element_width
+        if buf_len % 2:
+            buf_len += 1
+
+        self.data = buff[self.format_general_size:self.format_general_size + buf_len]
 
     def add_note(self, msg):
       """


### PR DESCRIPTION
For the fill array instruction, the play load length is defined:
Note: The total number of code units for an instance of this table is (size * element_width + 1) / 2 + 4.

What it really means that is to round size * element_width in size of two bytes.

For example:
Suppose the size*element_width = 1, then  (1+1)/2 + 4 = 5  (2 byte code units).
And if size*element_width = 2, then (2+1)/2 + 4 = 5 ( 1.5 is truncated into 1 when performing integer division).

Therefore, it round the odd size*element_width and keeps the even size*element_width.

The original implementation actually add one byte to the length of payload, which is utterly wrong.

