### PR TITLE
Update dvm.py

### DIFF
--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -2889,7 +2889,7 @@ class EncodedMethod(object):
 
             :rtype: an :class:`Instruction` object
         """
-        if self._code != None:
+        if self.code != None:
             return self.code.get_bc().get_instruction(idx, off)
         return None
 


### PR DESCRIPTION
Extra '_' in get_instruction(). In its current state the method fails with:
 File "./androguard/core/bytecodes/dvm.py", line 2918, in get_instruction
    if self._code != None:
AttributeError: 'EncodedMethod' object has no attribute '_code'