### PR TITLE
Replace distribute dependency with setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,4 @@ setup(
              'androsim.py',
              'androdd.py',
              'androgui.py',],
-    install_requires=['distribute'],)
+    setup_requires=['setuptools'],)


### PR DESCRIPTION
Also, it's no use to require it during the installation process. Instead, specify that it is required for setup.
