### PR TITLE
Fix APK signature methods.

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -866,17 +866,47 @@ class APK(object):
             return self.arsc["resources.arsc"]
 
     def get_signature_name(self):
-        signature_expr = re.compile("^(META-INF/)(.*)(\.RSA|\.DSA)$")
+        """
+            Return the name of the first signature file found.
+        """
+        return self.get_signature_names_list()[0]
+
+    def get_signature_names(self):
+        """
+             Return a list of the signature file names.
+        """
+        signature_expr = re.compile("^(META-INF/)(.*)(\.RSA|\.EC|\.DSA)$")
+        signatures = []
+
         for i in self.get_files():
             if signature_expr.search(i):
-                return i
+                signatures.append(i)
+
+        if len(signatures) > 0:
+            return signatures
+
         return None
 
     def get_signature(self):
-        signature_expr = re.compile("^(META-INF/)(.*)(\.RSA|\.DSA)$")
+        """
+            Return the data of the first signature file found.
+        """
+        return self.get_signature_list()[0]
+
+    def get_signatures(self):
+        """
+            Return a list of the data of the signature files.
+        """
+        signature_expr = re.compile("^(META-INF/)(.*)(\.RSA|\.EC|\.DSA)$")
+        signature_datas = []
+
         for i in self.get_files():
             if signature_expr.search(i):
-                return self.get_file(i)
+                signature_datas.append(self.get_file(i))
+
+        if len(signature_datas) > 0:
+            return signature_datas
+
         return None
 
     def show(self):


### PR DESCRIPTION
APKs can be signed using RSA, DSA and EC keys. This
change allows you to be able to see the EC key suffix
when searching an APK. I've also added new methods to
return a list of _all_ signatures found opposed to just
the first.

The older methods are still available for backwards
compatability. They have been refactored to select
the first of the list, which is how the previous
functionality would have worked.