### PR TITLE
added SIGNATURE definitions

### DIFF
--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -517,6 +517,40 @@ class MethodAnalysis(object):
       """
         return self.tags
 
+SIGNATURE_L0_0 = "L0_0"
+SIGNATURE_L0_1 = "L0_1"
+SIGNATURE_L0_2 = "L0_2"
+SIGNATURE_L0_3 = "L0_3"
+SIGNATURE_L0_4 = "L0_4"
+SIGNATURE_L0_5 = "L0_5"
+SIGNATURE_L0_6 = "L0_6"
+SIGNATURE_L0_0_L1 = "L0_0:L1"
+SIGNATURE_L0_1_L1 = "L0_1:L1"
+SIGNATURE_L0_2_L1 = "L0_2:L1"
+SIGNATURE_L0_3_L1 = "L0_3:L1"
+SIGNATURE_L0_4_L1 = "L0_4:L1"
+SIGNATURE_L0_5_L1 = "L0_5:L1"
+SIGNATURE_L0_0_L2 = "L0_0:L2"
+SIGNATURE_L0_0_L3 = "L0_0:L3"
+SIGNATURE_HEX = "hex"
+SIGNATURE_SEQUENCE_BB = "sequencebb"
+
+SIGNATURES = {
+    SIGNATURE_L0_0: {"type": 0},
+    SIGNATURE_L0_1: {"type": 1},
+    SIGNATURE_L0_2: {"type": 2,
+                     "arguments": ["Landroid"]},
+    SIGNATURE_L0_3: {"type": 2,
+                     "arguments": ["Ljava"]},
+    SIGNATURE_L0_4: {"type": 2,
+                     "arguments": ["Landroid", "Ljava"]},
+    SIGNATURE_L0_5: {"type": 3,
+                     "arguments": ["Landroid"]},
+    SIGNATURE_L0_6: {"type": 3,
+                     "arguments": ["Ljava"]},
+    SIGNATURE_SEQUENCE_BB: {},
+    SIGNATURE_HEX: {},
+}
 
 class StringAnalysis(object):
 


### PR DESCRIPTION
added SIGNATURE definitions that were deleted at commit
6b24ddf7d385e8a9062de7ae95d7e8dfb12f7b1c which results an error when
androsign, androcsign and andrdiff tolls are run.