### PR TITLE
Support finding main activity via activity aliases

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -581,7 +581,10 @@ class APK(object):
         y = set()
 
         for i in self.xml:
-            for item in self.xml[i].getElementsByTagName("activity"):
+            activities_and_aliases = self.xml[i].getElementsByTagName("activity") + \
+                                     self.xml[i].getElementsByTagName("activity-alias")
+
+            for item in activities_and_aliases:
                 for sitem in item.getElementsByTagName("action"):
                     val = sitem.getAttributeNS(NS_ANDROID_URI, "name")
                     if val == "android.intent.action.MAIN":


### PR DESCRIPTION
`com.expedia.bookings` has it's main activity defined only in an activity alias:

``` xml
<activity-alias android:name="com.expedia.bookings.activity.SearchActivity" android:targetActivity="com.expedia.bookings.activity.RouterActivity">
            <intent-filter>
                <action android:name="android.intent.action.MAIN" />
                <category android:name="android.intent.category.DEFAULT" />
                <category android:name="android.intent.category.LAUNCHER" />
            </intent-filter>
        </activity-alias>
```

When attempting to retrieve the main activity with Androguard:

```
In [7]: from androguard.core.bytecodes.apk import APK
In [8]: a = APK("/Users/fuzion24/Downloads/com.expedia.bookings.apk")
In [9]: a.get_main_activity()
In [10]:
```

After the patch:

```
In [5]: from androguard.core.bytecodes.apk import APK
In [6]:  a = APK("/Users/fuzion24/Downloads/com.expedia.bookings.apk")
In [7]: a.get_main_activity()
Out[7]: u'com.expedia.bookings.activity.SearchActivity'
```
