### PR TITLE
Correct encoding for non-ascii values

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -527,7 +527,7 @@ class APK(object):
                 value = item.getAttributeNS(NS_ANDROID_URI, attribute)
                 value = self.format_value(value)
 
-                l.append(str(value))
+                l.append(unicode(value))
         return l
 
     def format_value(self, value):


### PR DESCRIPTION
Non-ASCII characters are found in the list of services (call of get_services() function).

Fix bug found with .apk with sha256:
0b8ba0c6cebe5695639bf1b282b52f126dba733f3c204e37615a3ba5f7dd6fe8

See issue #148 for more details.
