### PR TITLE
Fix 309aa68 to properly check if APK.

### DIFF
--- a/androguard/core/androconf.py
+++ b/androguard/core/androconf.py
@@ -222,7 +222,7 @@ def is_android(filename):
 def is_android_raw(raw):
     val = None
 
-    if raw[0:2] == "PK":
+    if raw[0:2] == "PK" and ('AndroidManifest.xml' in raw and 'META-INF/MANIFEST.MF' in raw):
         val = "APK"
     elif raw[0:3] == "dex":
         val = "DEX"
@@ -234,9 +234,6 @@ def is_android_raw(raw):
         val = "AXML"
     elif raw[0:4] == "\x02\x00\x0C\x00":
         val = "ARSC"
-    elif ('AndroidManifest.xml' in raw and
-          'META-INF/MANIFEST.MF' in raw):
-        val = "APK"
 
     return val
 


### PR DESCRIPTION
This is actually now similar to how TIKA checks if it
is an APK by checking if;
1. Magic is PK (zip)
2. Contains a Android Manifest (required)
3. Is signed (Manifest.mf)
