### PR TITLE
Arsc corrections

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -1839,7 +1839,11 @@ class ARSCParser(object):
 
         try:
             for i in self.values[package_name][locale]["string"]:
-                buff += '<string name="%s">%s</string>\n' % (i[0], i[1])
+                if any(map(i[1].__contains__, '<&>')):
+                    value = '<![CDATA[%s]]>' % i[1]
+                else:
+                    value = i[1]
+                buff += '<string name="%s">%s</string>\n' % (i[0], value)
         except KeyError:
             pass
 


### PR DESCRIPTION
The only APK so far that can be used to reproduce a crash which is fixed by this PR can be downloaded [from google play](https://play.google.com/store/apps/details?id=com.alibaba.intl.android.apps.poseidon)

I am not sure if it is OK to include 3rd party APK or even it's resources file into the test suite, so I didn't do that.

On the other hand, I am also not aware of an easy way to generate an arsc file with the non-standard header sizes (which is the reason for the crash). 
