### PR TITLE
fix bug on getting main activity

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -582,6 +582,9 @@ class APK(object):
 
         for i in self.xml:
             for item in self.xml[i].getElementsByTagName("activity"):
+                activityEnabled = item.getAttributeNS(NS_ANDROID_URI, "enabled")
+                if activityEnabled is not None and activityEnabled != "" and activityEnabled is not True:
+                    continue
                 for sitem in item.getElementsByTagName("action"):
                     val = sitem.getAttributeNS(NS_ANDROID_URI, "name")
                     if val == "android.intent.action.MAIN":

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -583,7 +583,7 @@ class APK(object):
         for i in self.xml:
             for item in self.xml[i].getElementsByTagName("activity"):
                 activityEnabled = item.getAttributeNS(NS_ANDROID_URI, "enabled")
-                if activityEnabled is not None and activityEnabled != "" and activityEnabled is not True:
+                if activityEnabled is not None and activityEnabled != "" and activityEnabled == "false":
                     continue
                 for sitem in item.getElementsByTagName("action"):
                     val = sitem.getAttributeNS(NS_ANDROID_URI, "name")


### PR DESCRIPTION
I found some malicious apps register several main activities as below:
there are 2 main activities but one of them has android:enabled="false"
that will lead to get wrong main activity by
androguard(a.get_main_activity method);
