### PR TITLE
Fix getAttributeNS may be return unicode and can't transform return v…

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -221,19 +221,20 @@ class APK(object):
                         # getting details of the declared permissions
                         for d_perm_item in self.xml[i].getElementsByTagName('permission'):
                             d_perm_name = self._get_res_string_value(str(
-                                d_perm_item.getAttributeNS(NS_ANDROID_URI, "name")))
+                                d_perm_item.getAttributeNS(NS_ANDROID_URI,
+                                                            "name").encode('utf-8')))
                             d_perm_label = self._get_res_string_value(str(
                                 d_perm_item.getAttributeNS(NS_ANDROID_URI,
-                                                           "label")))
+                                                           "label").encode('utf-8')))
                             d_perm_description = self._get_res_string_value(str(
                                 d_perm_item.getAttributeNS(NS_ANDROID_URI,
-                                                           "description")))
+                                                           "description").encode('utf-8')))
                             d_perm_permissionGroup = self._get_res_string_value(str(
                                 d_perm_item.getAttributeNS(NS_ANDROID_URI,
-                                                           "permissionGroup")))
+                                                           "permissionGroup").encode('utf-8')))
                             d_perm_protectionLevel = self._get_res_string_value(str(
                                 d_perm_item.getAttributeNS(NS_ANDROID_URI,
-                                                           "protectionLevel")))
+                                                           "protectionLevel").encode('utf-8')))
 
                             d_perm_details = {
                                 "label": d_perm_label,

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -216,13 +216,13 @@ class APK(object):
 
                         for item in self.xml[i].getElementsByTagName('uses-permission'):
                             self.permissions.append(str(item.getAttributeNS(
-                                NS_ANDROID_URI, "name")))
+                                NS_ANDROID_URI, "name").encode('utf-8')))
 
                         # getting details of the declared permissions
                         for d_perm_item in self.xml[i].getElementsByTagName('permission'):
                             d_perm_name = self._get_res_string_value(str(
                                 d_perm_item.getAttributeNS(NS_ANDROID_URI,
-                                                            "name").encode('utf-8')))
+                                                           "name").encode('utf-8')))
                             d_perm_label = self._get_res_string_value(str(
                                 d_perm_item.getAttributeNS(NS_ANDROID_URI,
                                                            "label").encode('utf-8')))


### PR DESCRIPTION
getAttributeNS may be return unicode string.
like this app: http://f1.market.mi-img.com/download/AppStore/084a35f702935823c9b2f0518776392209b40ad4a/com.tencent.mobileqq.apk

may be raise:
     UnicodeEncodeError: 'ascii' codec can't encode characters in position 2-5: ordinal not in range(128)
