### PR TITLE
Added 'android:UNKNOWN_SYSTEM_ATTRIBUTE' for unfound attributes

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -1374,6 +1374,8 @@ class AXMLParser(object):
                 res = 'android:' + public.SYSTEM_RESOURCES['attributes']['inverse'][
                     attr
                 ]
+            else:
+                res = 'android:UNKNOWN_SYSTEM_ATTRIBUTE'
 
         return res
 


### PR DESCRIPTION
This fixes a bug (error calling function on None type) caused when a
system attribute is encountered that is not in the list of system
attributes in android.core.resources.public. This was encountered
when an AndroidManifest.xml file contained a tag with a newer system
attribute (e.g. <intent-filter android:autoVerify="true">) The
"autoVerify" string is not found in android.core.resources.public
so None is returned. This causes the AXMLPrinter to print XML that
is invalid, eventually causing minidom to fail to parse it. Then
when an analyzer tries to lookup a value in the AndroidManifest the
 lookup fails because the xml is None and analysis can't proceed.

By returning a default value when a system attribute lookup fails, we
future proof against other unknown SYSTEM_ATTRIBUTES
