### PR TITLE
Add Support For Filemagic

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -413,7 +413,7 @@ class APK(object):
             getattr(magic, "MagicException")
         except AttributeError:
             try:
-                getattr(magic, "id_buffer")
+                getattr(magic.Magic, "id_buffer")
                 filemagic = 1
             except AttributeError:
                 builtin_magic = 1


### PR DESCRIPTION
This PR allows for filemagic support in addition to python-magic. This is needed for environments already making use of filemagic, because python-magic and filemagic cannot be used in the same environment or virtual environment.

This PR also addresses the issue raised in #124.