### PR TITLE
remove inline assembly in RDTSC: now CLOCK_MONOTONIC

### DIFF
--- a/elsim/elsim/similarity/libsimilarity/similarity.c
+++ b/elsim/elsim/similarity/libsimilarity/similarity.c
@@ -329,26 +329,13 @@ unsigned int kolmogorov(int level, void *orig, size_t size_orig)
 
 /* Haypo */
 
+/* returns the number of seconds since some point; always increasing.
+ * Used only for timing operations.
+ */
 double RDTSC(void) {
-#if defined linux || defined __APPLE__
-    unsigned long long x;
-    __asm__ volatile (".byte 0x0f, 0x31" : "=A"(x));
-    return (double)x;
-#else
-    unsigned long a, b;
-    double x;
-    asm
-    {
-        db 0x0F, 0x31
-            mov [a], eax
-            mov [b], eax
-    }
-
-    x = b;
-    x *= 4294967296;
-    x += a;
-    return x;
-#endif
+    struct timespec time;
+    clock_gettime(CLOCK_MONOTONIC, &time);
+    return time.tv_sec + time.tv_nsec / 1e9;
 }
 
 double bennett(int level, void *orig, size_t size_orig)

--- a/elsim/elsim/similarity/libsimilarity/similarity.h
+++ b/elsim/elsim/similarity/libsimilarity/similarity.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+#include <time.h>
 
 #include "./z/z.h"
 #include "./bz2/bz2.h"


### PR DESCRIPTION
The inline assembly in this function:

 * breaks compiling on non-x86 platforms like ARM
 * probably doesn't work on multi-core systems in general (i.e. most x86 computers now)
 * probably doesn't work on anything with power saving
 * probably doesn't work at all on x86_64, as the `"=A"` might be wrong
 * doesn't seem to be actually used anywhere

Please either remove it, or replace it with `clock_gettime(CLOCK_MONOTONIC, ..`, which is at least, not broken.
