### PR TITLE
Add skip files parse param

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -248,7 +248,6 @@ class APK(object):
 
                         self.valid_apk = True
 
-            self.get_files_types()
             self.permission_module = androconf.load_api_specific_resource_module(
                 "aosp_permissions", self.get_target_sdk_version())
 
@@ -479,7 +478,7 @@ class APK(object):
     def get_files_crc32(self):
         """
         Calculates and returns a dictionary of filenames and CRC32
-        
+
         :return: dict of filename: CRC32
         """
         if self.files_crc32 == {}:
@@ -1019,7 +1018,7 @@ class APK(object):
 def get_Name(name, short=False):
     """
         Return the distinguished name of an X509 Certificate
-        
+
         :param name: Name object to return the DN from
         :param short: Use short form (Default: False)
 


### PR DESCRIPTION
The get_files_types method is the most CPU intensive part of parsing an APK and on some bigger APKs can take minutes depending on your machine.  This param lets you optionally skip it.