### PR TITLE
.encode('utf-8') instead of str()

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -556,7 +556,7 @@ class APK(object):
                 value = item.getAttributeNS(NS_ANDROID_URI, attribute)
                 value = self.format_value(value)
 
-                l.append(str(value))
+                l.append(value.encode('utf-8'))
         return l
 
     def format_value(self, value):


### PR DESCRIPTION
Using str() causes UnicodeEncodeError in get_elements(), hence in get_activities(), get_services(), etc.
![image](https://user-images.githubusercontent.com/5960869/29493313-4657bf74-859c-11e7-8397-963f59cb3a35.png)
![image](https://user-images.githubusercontent.com/5960869/29493316-4c9dca40-859c-11e7-8676-aaca3a6c0a21.png)
