### PR TITLE
try to fix decompiler crashes due to tmp variables

### DIFF
--- a/androguard/decompiler/dad/dataflow.py
+++ b/androguard/decompiler/dad/dataflow.py
@@ -328,7 +328,8 @@ class DummyNode(Node):
 def group_variables(lvars, DU, UD):
     treated = defaultdict(list)
     variables = defaultdict(list)
-    for var, loc in sorted(DU):
+    # FIXME
+    for var, loc in sorted(DU, key=lambda x: (str(x[0]), str(x[1]))):
         if var not in lvars:
             continue
         if loc in treated[var]:

--- a/androguard/decompiler/dad/decompile.py
+++ b/androguard/decompiler/dad/decompile.py
@@ -265,7 +265,10 @@ class DvClass(object):
 
     def process(self, doAST=False):
         for i in range(len(self.methods)):
-            self.process_method(i, doAST=doAST)
+            try:
+                self.process_method(i, doAST=doAST)
+            except Exception as e:
+                logger.warning('Error decompiling method %s: %s', self.methods[i], e)
 
     def get_ast(self):
         fields = [get_field_ast(f) for f in self.fields]

--- a/androguard/decompiler/dad/decompile.py
+++ b/androguard/decompiler/dad/decompile.py
@@ -148,6 +148,12 @@ class DvMethod(object):
         dead_code_elimination(graph, def_uses, use_defs)
         register_propagation(graph, def_uses, use_defs)
 
+        # FIXME var_to_name need to contain the created tmp variables.
+        # This seems to be a workaround, we add them into the list manually
+        for var, i in def_uses:
+            if isinstance(var, str):
+                self.var_to_name[var] = var.upper()
+
         place_declarations(graph, self.var_to_name, def_uses, use_defs)
         del def_uses, use_defs
         # After the DCE pass, some nodes may be empty, so we can simplify the
@@ -259,11 +265,7 @@ class DvClass(object):
 
     def process(self, doAST=False):
         for i in range(len(self.methods)):
-            try:
-                self.process_method(i, doAST=doAST)
-            except Exception as e:
-                logger.debug(
-                    'Error decompiling method %s: %s', self.methods[i], e)
+            self.process_method(i, doAST=doAST)
 
     def get_ast(self):
         fields = [get_field_ast(f) for f in self.fields]


### PR DESCRIPTION
fixes for crashes if tmp variables are created but later not found