### PR TITLE
Run tests with PyPy 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7-dev"
-  - "pypy"
+  - "pypy2-5.9.0"
 # command to install dependencies
 install:
   - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7-dev"
+  - "pypy"
 # command to install dependencies
 install:
   - "pip install ."


### PR DESCRIPTION
Since this is a pure python library I see no reason why PyPy shouldn't be supported.
Let's see if this is a no brainer.