### PR TITLE
fixing #354 with unit tests and #355

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -535,7 +535,7 @@ class APK(object):
                 value = item.getAttributeNS(NS_ANDROID_URI, attribute)
                 value = self.format_value(value)
 
-                l.append(value.encode('utf-8'))
+                l.append(value)
         return l
 
     def format_value(self, value):
@@ -867,11 +867,11 @@ class APK(object):
         for item in self.zip.infolist():
             if deleted_files is not None:
                 if re.match(deleted_files, item.filename) is None:
-                    if item.filename in new_files:
-                        zout.writestr(item, new_files[item.filename])
-                    else:
-                        buffer = self.zip.read(item.filename)
-                        zout.writestr(item, buffer)
+                    buffer = self.zip.read(item.filename)
+                    zout.writestr(item, buffer)
+            if new_files is not False:
+                if item.filename in new_files:
+                    zout.writestr(item, new_files[item.filename])
         zout.close()
 
     def get_android_manifest_axml(self):

--- a/tests/test_apk.py
+++ b/tests/test_apk.py
@@ -144,6 +144,37 @@ class APKTest(unittest.TestCase):
                                                                   "android.permission.BROADCAST_STICKY",
                                                                   "android.permission.GET_ACCOUNTS"]))
 
+    def testAPKActivitiesAreString(self):
+        from androguard.core.bytecodes.apk import APK
+        a = APK("examples/tests/a2dp.Vol_137.apk", testzip=True)
+        activities = a.get_activities()
+        self.assertTrue(isinstance(activities[0], str), 'activities[0] is not of type str')
+
+    def testAPKIntentFilters(self):
+        from androguard.core.bytecodes.apk import APK
+        a = APK("examples/tests/a2dp.Vol_137.apk", testzip=True)
+        activities = a.get_activities()
+        receivers = a.get_receivers()
+        services = a.get_services()
+        filter_list = []
+        for i in activities:
+            filters = a.get_intent_filters("activity", i)
+            if len(filters) > 0:
+                filter_list.append(filters)
+        for i in receivers:
+            filters = a.get_intent_filters("receiver", i)
+            if len(filters) > 0:
+                filter_list.append(filters)
+        for i in services:
+            filters = a.get_intent_filters("service", i)
+            if len(filters) > 0:
+                filter_list.append(filters)
+        pairs = zip(filter_list, [{'action': ['android.intent.action.MAIN'], 'category': ['android.intent.category.LAUNCHER']},
+                                                         {'action': ['android.service.notification.NotificationListenerService']},
+                                                         {'action': ['android.intent.action.BOOT_COMPLETED', 'android.intent.action.MY_PACKAGE_REPLACED'], 'category': ['android.intent.category.HOME']},
+                                                         {'action': ['android.appwidget.action.APPWIDGET_UPDATE']}])
+        self.assertTrue(any(x != y for x, y in pairs))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#354 resolved with changes on line 538 of apk.py. Tests added in test_apk.py to test that a string type is returned for get_activities(), which currently returns a byte class.

#355 resolved with moving the new_files check outside of the deleted_files check. No tests for this, and I haven't added any in this PR.