### PR TITLE
Allow multidex analysis

### DIFF
--- a/androguard/misc.py
+++ b/androguard/misc.py
@@ -49,8 +49,8 @@ def AnalyzeAPK(_file, session=None, raw=False):
             data = fd.read()
             filename = _file
 
-    session.add(filename, data)
-    return session.get_objects_apk(filename)
+    digest = session.add(filename, data)
+    return session.get_objects_apk_by_digest(digest)
 
 
 def AnalyzeDex(filename, session=None):

--- a/androguard/misc.py
+++ b/androguard/misc.py
@@ -50,7 +50,7 @@ def AnalyzeAPK(_file, session=None, raw=False):
             filename = _file
 
     digest = session.add(filename, data)
-    return session.get_objects_apk_by_digest(digest)
+    return session.get_objects_apk(filename, digest)
 
 
 def AnalyzeDex(filename, session=None):

--- a/androguard/session.py
+++ b/androguard/session.py
@@ -226,18 +226,14 @@ class Session(object):
         for digest in self.analyzed_apk:
             yield digest, self.analyzed_apk[digest]
 
-    def get_objects_apk(self, filename):
-        digests = self.analyzed_files.get(filename)
-        # Negate to reduce tree
-        if not digests:
-            return None, None, None
-        digest = digests[0]
+    def get_objects_apk(self, filename, digest=None):
+        if digest is None:
+            digests = self.analyzed_files.get(filename)
+            # Negate to reduce tree
+            if not digests:
+                return None, None, None
+            digest = digests[0]
 
-        a = self.analyzed_apk[digest][0]
-        dx = self.analyzed_vms[digest]
-        return a, dx.vms, dx
-
-    def get_objects_apk_by_digest(self, digest):
         a = self.analyzed_apk[digest][0]
         dx = self.analyzed_vms[digest]
         return a, dx.vms, dx

--- a/androguard/session.py
+++ b/androguard/session.py
@@ -110,6 +110,16 @@ class Session(object):
             log.debug("Exporting in ipython")
             d.create_python_export()
 
+        if dx is None:
+            dx = Analysis()
+
+        dx.add(d)
+        dx.create_xref()
+
+        for d in dx.vms:
+            d.set_decompiler(DecompilerDAD(d, dx))
+            d.set_vmanalysis(dx)
+
         return digest, d, dx
 
     def addDEY(self, filename, data, dx=None):
@@ -126,6 +136,16 @@ class Session(object):
 
         if self.export_ipython:
             d.create_python_export()
+
+        if dx is None:
+            dx = Analysis()
+
+        dx.add(d)
+        dx.create_xref()
+
+        for d in dx.vms:
+            d.set_decompiler(DecompilerDAD(d, dx))
+            d.set_vmanalysis(dx)
 
         return digest, d, dx
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -15,6 +15,7 @@ class SessionTest(unittest.TestCase):
             self.assertEqual(len(s.analyzed_apk), 0)
             self.assertEqual(len(s.analyzed_files), 1)
             self.assertEqual(len(s.analyzed_digest), 1)
+            self.assertEqual(len(s.analyzed_vms), 0)
             self.assertEqual(len(s.analyzed_dex), 1)
 
     def testSessionAPK(self):
@@ -26,6 +27,7 @@ class SessionTest(unittest.TestCase):
             self.assertEqual(len(s.analyzed_apk), 1)
             self.assertEqual(len(s.analyzed_files), 1)
             self.assertEqual(len(s.analyzed_digest), 2)
+            self.assertEqual(len(s.analyzed_vms), 1)
             self.assertEqual(len(s.analyzed_dex), 1)
 
     def testSessionSave(self):


### PR DESCRIPTION
Following are the changes:

1. Instead of using the `last_vm` get the `vm` dynamically via ClassManager
2. do the analysis on all the `vm` present in `self.vms`
3. Refactor `session.py` to support multidex analysis

@reox @adesnos can you please review the changes ? I'll write testcases in different PR

fixes #373 #359
