### PR TITLE
Make ASCII detection compatible with Python3

### DIFF
--- a/androguard/core/androconf.py
+++ b/androguard/core/androconf.py
@@ -25,9 +25,9 @@ def is_ascii_problem(s):
     :return: True if string contains other chars than ASCII, False otherwise
     """
     try:
-        s.decode("ascii")
+        s.encode("ascii")
         return False
-    except UnicodeDecodeError:
+    except (UnicodeEncodeError, UnicodeDecodeError):
         return True
 
 


### PR DESCRIPTION
In `Python3` you can't call `decode()` on a `str` object, so this workaround should work with both `Python2` and `Python3`.