### PR TITLE
  switch pyasn1 to asn1crypto

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -21,11 +21,7 @@ import lxml.sax
 from xml.dom.pulldom import SAX2DOM
 
 # Used for reading Certificates
-from pyasn1.codec.der.decoder import decode
-from pyasn1.codec.der.encoder import encode
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes
+from asn1crypto import cms, x509
 
 NS_ANDROID_URI = 'http://schemas.android.com/apk/res/android'
 NS_ANDROID = '{http://schemas.android.com/apk/res/android}'
@@ -1000,24 +996,8 @@ class APK(object):
         """
         pkcs7message = self.get_file(filename)
 
-        # TODO for correct parsing, we would need to write our own ASN1Spec for the SignatureBlock format
-        message, _ = decode(pkcs7message)
-        cert = encode(message[1][3])
-        # Remove the first identifier
-        # byte 0 == identifier, skip
-        # byte 1 == length. If byte1 & 0x80 > 1, we have long format
-        #                   The length of to read bytes is then coded
-        #                   in byte1 & 0x7F
-        # Check if the first byte is 0xA0 (Sequence Tag)
-        tag = cert[0]
-        l = cert[1]
-        # Python2 compliance
-        if not isinstance(l, int):
-            l = ord(l)
-            tag = ord(tag)
-        if tag == 0xA0:
-            cert = cert[2 + (l & 0x7F) if l & 0x80 > 1 else 2:]
-
+        pkcs7obj = cms.ContentInfo.load(pkcs7message)
+        cert = pkcs7obj['content']['certificates'][0].chosen.dump()
         return cert
 
     def get_certificate(self, filename):
@@ -1028,7 +1008,7 @@ class APK(object):
         :return: a :class:`Certificate` certificate
         """
         cert = self.get_certificate_der(filename)
-        certificate = x509.load_der_x509_certificate(cert, default_backend())
+        certificate = x509.Certificate.load(cert)
 
         return certificate
 
@@ -1241,14 +1221,14 @@ class APK(object):
 
     def get_certificates_v2(self):
         """
-        Return a list of :class:`cryptography.x509.Certificate` which are found
+        Return a list of :class:`asn1crypto.x509.Certificate` which are found
         in the v2 signing block.
         Note that we simply extract all certificates regardless of the signer.
         Therefore this is just a list of all certificates found in all signers.
         """
         certs = []
         for cert in self.get_certificates_der_v2():
-            certs.append(x509.load_der_x509_certificate(cert, default_backend()))
+            certs.append(x509.Certificate.load(cert))
 
         return certs
 
@@ -1367,12 +1347,13 @@ def show_Certificate(cert, short=False):
         :param cert: X509 Certificate to print
         :param short: Print in shortform for DN (Default: False)
 
-        :type cert: :class:`cryptography.x509.Certificate`
+        :type cert: :class:`asn1crypto.x509.Certificate`
         :type short: Boolean
     """
 
-    for h in [hashes.MD5, hashes.SHA1, hashes.SHA256, hashes.SHA512]:
-        print("{}: {}".format(h.name, binascii.hexlify(cert.fingerprint(h())).decode("ascii")))
-    print("Issuer: {}".format(get_certificate_name_string(cert.issuer, short=short)))
-    print("Subject: {}".format(get_certificate_name_string(cert.subject, short=short)))
+
+    print("SHA1: {}".format(cert.sha1_fingerprint))
+    print("SHA512: {}".format(cert.sha256_fingerprint))
+    print("Issuer: {}".format(get_certificate_name_string(cert.issuer.native, short=short)))
+    print("Subject: {}".format(get_certificate_name_string(cert.issuer.native, short=short)))
 

--- a/androguard/util.py
+++ b/androguard/util.py
@@ -21,15 +21,29 @@ def get_certificate_name_string(name, short=False):
 
     # For the shortform, we have a lookup table
     # See RFC4514 for more details
-    sf = {
-        "countryName": "C",
-        "stateOrProvinceName": "ST",
-        "localityName": "L",
-        "organizationalUnitName": "OU",
-        "organizationName": "O",
-        "commonName": "CN",
-        "emailAddress": "E",
+    _ = {
+        'business_category' : ("businessCategory", "businessCategory"),
+        'serial_number' : ("serialNumber", "serialNumber"),
+        'country_name' : ("C", "countryName"),
+        'postal_code' : ("postalCode", "postalCode"),
+        'state_or_province_name' : ("ST", "stateOrProvinceName"),
+        'locality_name' : ("L", "localityName"),
+        'street_address' : ("street", "streetAddress"),
+        'organization_name' : ("O", "organizationName"),
+        'organizational_unit_name' : ("OU", "organizationalUnitName"),
+        'title' : ("title", "title"),
+        'common_name' : ("CN", "commonName"),
+        'initials' : ("initials", "initials"),
+        'generation_qualifier' : ("generationQualifier", "generationQualifier"),
+        'surname' : ("SN", "surname"),
+        'given_name' : ("GN", "givenName"),
+        'name' : ("name", "name"),
+        'pseudonym' : ("pseudonym", "pseudonym"),
+        'dn_qualifier' : ("dnQualifier", "dnQualifier"),
+        'telephone_number' : ("telephoneNumber", "telephoneNumber"),
+        'email_address' : ("E", "emailAddress"),
+        'domain_component' : ("DC", "domainComponent"),
+        'name_distinguisher' : ("nameDistinguisher", "nameDistinguisher"),
+        'organization_identifier' : ("organizationIdentifier", "organizationIdentifier"),
     }
-    return ", ".join(
-        ["{}={}".format(attr.oid._name if not short or attr.oid._name not in sf else sf[attr.oid._name], attr.value) for
-         attr in name])
+    return ", ".join(["{}={}".format(_.get(attr,(attr,attr))[0 if short else 1], name[attr]) for attr in name])

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,13 @@ if (sys.version_info.major == 3 and sys.version_info.minor < 4) or (sys.version_
 if sys.version_info <= (3, 4):
     print("PyQT5 is probably not available for your system, the GUI might not work!", file=sys.stderr)
 
-# There is a bug in pyasn1 0.3.1, 0.3.2 and 0.3.3, so do not use them!
-# Version 0.3.4 produces wrong certificates in some cases!
-install_requires = ['pyasn1!=0.3.1,!=0.3.2,!=0.3.3,!=0.3.4,!=0.4.1',
-                    'future',
+install_requires = ['future',
                     'networkx>=1.11',
                     'pygments',
                     'lxml',
                     'colorama',
                     'matplotlib',
-                    'cryptography>=2.0',
+                    'asn1crypto',
                     ]
 
 # python version specific library versions:


### PR DESCRIPTION
so many bugs in pyasn1. asn1crypto is more easy in use, and no need cryptography any more.