### PR TITLE
python2 didn't support unicode with format

### DIFF
--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -2127,7 +2127,7 @@ class ProtoIdItem(object):
         """
         if self.parameters_off_value is None:
             params = self.CM.get_type_list(self.parameters_off)
-            self.parameters_off_value = '({})'.format(' '.join(params))
+            self.parameters_off_value = u'({})'.format(' '.join(params))
         return self.parameters_off_value
 
     def show(self):


### PR DESCRIPTION
I was tested this apk [snaptube](https://apkpure.com/snaptube/com.snaptube.premium).
It took error this `  File "/home/x/androguard/core/bytecodes/dvm.py", line 7246, in get_proto
    return [proto.get_parameters_off_value(),
  File "/home/x/androguard/core/bytecodes/dvm.py", line 2096, in get_parameters_off_value
    self.parameters_off_value = '({})'.format(' '.join(params))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u15ee' in position 3: ordinal not in range(128)`

so i add keyword u(unicode) to format string and it's working good.
