### PR TITLE
fix bug for xref from multi dex

### DIFF
--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -1032,7 +1032,10 @@ class Analysis:
                     if method_info:
                         class_info = method_info[0]
 
-                        method_item = instruction.cm.vm.get_method_descriptor(method_info[0], method_info[1], ''.join(method_info[2]))
+                        for vm in self.vms:
+                            method_item = vm.get_method_descriptor(method_info[0], method_info[1], ''.join(method_info[2]))
+                            if method_item:
+                                break
 
                         if not method_item:
                             if method_info[0] not in self.classes:


### PR DESCRIPTION
If an apk contains multiple dex for instance `classes1.dex` and `classes2.dex`. If method `A`  in `classes1.dex` invokes method `B` which is in `classes2.dex`, method `B` will only be searched in `classes1.dex`. So we will get nothing because method `B` is in `classes2.dex`. Instead we should search all classesN.dex for method `B`.