### PR TITLE
Fix `NoneType` obj has no attribute `findall`.

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -674,6 +674,8 @@ class APK(object):
         y = set()
 
         for i in self.xml:
+            if self.xml[i] is None:
+                continue
             activities_and_aliases = self.xml[i].findall(".//activity") + \
                                      self.xml[i].findall(".//activity-alias")
 

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -599,6 +599,8 @@ class APK(object):
         :param attribute: a string which specify the attribute
         """
         for i in self.xml:
+            if self.xml[i] is None:
+                continue
             for item in self.xml[i].findall('.//' + tag_name):
                 if with_namespace:
                     value = item.get(NS_ANDROID + attribute)


### PR DESCRIPTION
It is raised from `APK.get_elements()` and `APK.get_main_activity()` when parsing of `AndroidManifest.xml` failed in `APK._apk_analysis()` - `self.xml["AndroidManifest.xml"] is set to `None`.

Same fix is already implemented in `APK.get_element()`.