### PR TITLE
Add APK.get_main_activities() method

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -683,7 +683,7 @@ class APK(object):
                 # Some applications have more than one MAIN activity.
                 # For example: paid and free content
                 activityEnabled = item.get(NS_ANDROID + "enabled")
-                if activityEnabled is not None and activityEnabled != "" and activityEnabled == "false":
+                if activityEnabled == "false":
                     continue
 
                 for sitem in item.findall(".//action"):

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -662,13 +662,13 @@ class APK(object):
                     return value
         return None
 
-    def get_main_activity(self):
+    def get_main_activities(self):
         """
-        Return the name of the main activity
+        Return names of the main activities
 
-        This value is read from the AndroidManifest.xml
+        These values are read from the AndroidManifest.xml
 
-        :rtype: str
+        :rtype: a set of str
         """
         x = set()
         y = set()
@@ -696,9 +696,19 @@ class APK(object):
                     if val == "android.intent.category.LAUNCHER":
                         y.add(item.get(NS_ANDROID + "name"))
 
-        z = x.intersection(y)
-        if len(z) > 0:
-            return self._format_value(z.pop())
+        return x.intersection(y)
+
+    def get_main_activity(self):
+        """
+        Return the name of the main activity
+
+        This value is read from the AndroidManifest.xml
+
+        :rtype: str
+        """
+        activities = self.get_main_activities()
+        if len(activities) > 0:
+            return self._format_value(activities.pop())
         return None
 
     def get_activities(self):


### PR DESCRIPTION
Nothing has changed for `APK.get_main_activity()`.
`get_main_activities()` uses previous implementation of the `APK.get_main_activity()` but returns all the found activities.