### PR TITLE
Do not return `None` in list of main-activities.

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -689,12 +689,20 @@ class APK(object):
                 for sitem in item.findall(".//action"):
                     val = sitem.get(NS_ANDROID + "name")
                     if val == "android.intent.action.MAIN":
-                        x.add(item.get(NS_ANDROID + "name"))
+                        activity = item.get(NS_ANDROID + "name")
+                        if activity is not None:
+                            x.add(item.get(NS_ANDROID + "name"))
+                        else:
+                            log.warning('Main activity without name')
 
                 for sitem in item.findall(".//category"):
                     val = sitem.get(NS_ANDROID + "name")
                     if val == "android.intent.category.LAUNCHER":
-                        y.add(item.get(NS_ANDROID + "name"))
+                        activity = item.get(NS_ANDROID + "name")
+                        if activity is not None:
+                            y.add(item.get(NS_ANDROID + "name"))
+                        else:
+                            log.warning('Launcher activity without name')
 
         return x.intersection(y)
 


### PR DESCRIPTION
Description of the method states that it returns list of strings, so `None`
should not be there. According to the [docs](https://developer.android.com/guide/topics/manifest/activity-element#nm), name must be specified, so warning is logged in such a case.

Sample hash: 1A26B4F5C1DAE78F62B064014A9250ED79292CBFFCD7E07A1A88B64CAAA317BE