### PR TITLE
create 'androguard apkid' command for quite APK identification

### DIFF
--- a/androguard/cli/entry_points.py
+++ b/androguard/cli/entry_points.py
@@ -371,6 +371,23 @@ def sign(hash_, print_all_hashes, show, apk):
     """Return the fingerprint(s) of all certificates inside an APK."""
     androsign_main(apk, hash_, print_all_hashes, show)
 
+@entry_point.command()
+@click.argument(
+    'apks',
+    nargs=-1,
+    required=False,
+    type=click.Path(exists=True),
+)
+def apkid(apks):
+    """Return the packageName/versionCode/versionName per APK as JSON."""
+    import json
+    import logging
+    logging.getLogger("androguard.axml").setLevel(logging.ERROR)
+    results = dict()
+    for apk in apks:
+        results[apk] = androguard.core.bytecodes.apk.get_apkid(apk)
+    print(json.dumps(results, indent=2))
+
 
 @entry_point.command()
 @click.option(


### PR DESCRIPTION
This first tries to do quick binary XML parsing to just get the values that are needed.  It will fallback to full androguard parsing, which is slow, if it can't find the versionName value or versionName is set to a Android String Resource (e.g. an integer hex value that starts with @).

@reox this is what we hacked together the other night