### PR TITLE
Fix KeyError in methods to get permissions

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -889,7 +889,7 @@ class APK(object):
         aosp_permissions = []
         all_permissions = self.get_permissions()
         for perm in all_permissions:
-            if perm in list(self.permission_module["AOSP_PERMISSIONS"].keys()):
+            if perm in list(self.permission_module.keys()):
                 aosp_permissions.append(perm)
         return aosp_permissions
 
@@ -902,7 +902,7 @@ class APK(object):
         l = {}
         for i in self.permissions:
             try:
-                l[i] = self.permission_module["AOSP_PERMISSIONS"][i]
+                l[i] = self.permission_module[i]
             except KeyError:
                 # if we have not found permission do nothing
                 continue
@@ -917,7 +917,7 @@ class APK(object):
         third_party_permissions = []
         all_permissions = self.get_permissions()
         for perm in all_permissions:
-            if perm not in list(self.permission_module["AOSP_PERMISSIONS"].keys()):
+            if perm not in list(self.permission_module.keys()):
                 third_party_permissions.append(perm)
         return third_party_permissions
 


### PR DESCRIPTION
This is a fix for issue #559. This fixes a `KeyError` exception in `get_details_permissions`, `get_requested_aosp_permissions` and `get_requested_aosp_permissions_details`.