### PR TITLE
Closes #582: Fix language and region utf-8 encoding

### DIFF
--- a/androguard/core/bytecodes/axml.py
+++ b/androguard/core/bytecodes/axml.py
@@ -1012,8 +1012,9 @@ class ARSCParser(object):
                         language = a_res_type.config.get_language()
                         region = a_res_type.config.get_country()
                         if region == "\x00\x00":
-                            locale = language
+                            locale = language.encode("utf-8")
                         else:
+                            language, region = language.encode("utf-8"), region.encode("utf-8")
                             locale = "{}-r{}".format(language, region)
 
                         c_value = self.values[package_name].setdefault(locale, {"public":[]})

--- a/androguard/core/bytecodes/axml.py
+++ b/androguard/core/bytecodes/axml.py
@@ -1009,13 +1009,7 @@ class ARSCParser(object):
                     if header.type == RES_TABLE_TYPE_TYPE:
                         a_res_type = self.packages[package_name][nb + 1]
 
-                        language = a_res_type.config.get_language()
-                        region = a_res_type.config.get_country()
-                        if region == "\x00\x00":
-                            locale = language.encode("utf-8")
-                        else:
-                            language, region = language.encode("utf-8"), region.encode("utf-8")
-                            locale = "{}-r{}".format(language, region)
+                        locale = a_res_type.config.get_language_and_region()
 
                         c_value = self.values[package_name].setdefault(locale, {"public":[]})
 


### PR DESCRIPTION
Fix unicode `language` and `region` not properly utf-8-encoded.