### PR TITLE
Add support for APK v3 signing block

### DIFF
--- a/androguard/cli/main.py
+++ b/androguard/cli/main.py
@@ -387,8 +387,9 @@ def androsign_main(args_apk, args_hash, args_all, show):
             print("{}, package: '{}'".format(os.path.basename(path), a.get_package()))
             print("Is signed v1: {}".format(a.is_signed_v1()))
             print("Is signed v2: {}".format(a.is_signed_v2()))
+            print("Is signed v3: {}".format(a.is_signed_v3()))
 
-            certs = set(a.get_certificates_der_v2() + [a.get_certificate_der(x) for x in a.get_signature_names()])
+            certs = set(a.get_certificates_der_v3() + a.get_certificates_der_v2() + [a.get_certificate_der(x) for x in a.get_signature_names()])
 
             if len(certs) > 0:
                 print("Found {} unique certificates".format(len(certs)))

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -1463,43 +1463,43 @@ class APK(object):
         #    * signatures
         #    * publickey
         
-        size_sequence, = unpack('<I', block.read(4))
+        size_sequence = self.read_uint32_le(block)
         assert size_sequence + 4 == len(block_bytes), "size of sequence and blocksize does not match"
         
         self._v3_signing_data = []
         while block.tell() < len(block_bytes):
 
             off_signer = block.tell()
-            size_signer, = unpack('<I', block.read(4))
+            size_signer = self.read_uint32_le(block)
             
             # read whole signed data, since we might to parse
             # content within the signed data, and mess up offset
-            len_signed_data, = unpack('<I', block.read(4))
+            len_signed_data = self.read_uint32_le(block)
             signed_data_bytes = block.read(len_signed_data)
             signed_data = io.BytesIO(signed_data_bytes)
 
             # Digests
-            len_digests, = unpack('<I', signed_data.read(4))
+            len_digests = self.read_uint32_le(signed_data)
             raw_digests = signed_data.read(len_digests)
             digests = self.parse_signatures_or_digests(raw_digests)
 
 
             # Certs
             certs = []
-            len_certs, = unpack('<I', signed_data.read(4))
+            len_certs = self.read_uint32_le(signed_data)
             start_certs = signed_data.tell()
             while signed_data.tell() < start_certs + len_certs:
 
-                len_cert, = unpack('<I', signed_data.read(4))
+                len_cert = self.read_uint32_le(signed_data)
                 cert = signed_data.read(len_cert)
                 certs.append(cert)
 
             # versions
-            signed_data_min_sdk, = unpack('<I', signed_data.read(4))
-            signed_data_max_sdk, = unpack('<I', signed_data.read(4))
+            signed_data_min_sdk = self.read_uint32_le(signed_data)
+            signed_data_max_sdk = self.read_uint32_le(signed_data)
 
             # Addional attributes
-            len_attr, = unpack('<I', signed_data.read(4))
+            len_attr = self.read_uint32_le(signed_data)
             attr = signed_data.read(len_attr)
 
             signed_data_object = APKV3SignedData()
@@ -1511,16 +1511,16 @@ class APK(object):
             signed_data_object.maxSDK = signed_data_max_sdk
 
             # versions (should be the same as signed data's versions)
-            signer_min_sdk, = unpack('<I', block.read(4))
-            signer_max_sdk, = unpack('<I', block.read(4))
+            signer_min_sdk = self.read_uint32_le(block)
+            signer_max_sdk = self.read_uint32_le(block)
 
             # Signatures
-            len_sigs, = unpack('<I', block.read(4))
+            len_sigs = self.read_uint32_le(block)
             raw_sigs = block.read(len_sigs)
             sigs = self.parse_signatures_or_digests(raw_sigs)
 
             # PublicKey
-            len_publickey, = unpack('<I', block.read(4))
+            len_publickey = self.read_uint32_le(block)
             publickey = block.read(len_publickey)
 
             signer = APKV3Signer()
@@ -1562,39 +1562,39 @@ class APK(object):
         #    * signatures
         #    * publickey
 
-        size_sequence, = unpack('<I', block.read(4))
+        size_sequence = self.read_uint32_le(block)
         assert size_sequence + 4 == len(block_bytes), "size of sequence and blocksize does not match"
 
         self._v2_signing_data = []
         while block.tell() < len(block_bytes):
 
             off_signer = block.tell()
-            size_signer, = unpack('<I', block.read(4))
+            size_signer = self.read_uint32_le(block)
             
 
             # read whole signed data, since we might to parse
             # content within the signed data, and mess up offset
-            len_signed_data, = unpack('<I', block.read(4))
+            len_signed_data = self.read_uint32_le(block)
             signed_data_bytes = block.read(len_signed_data)
             signed_data = io.BytesIO(signed_data_bytes)
 
                 
             # Digests
-            len_digests, = unpack('<I', signed_data.read(4))
+            len_digests = self.read_uint32_le(signed_data)
             raw_digests = signed_data.read(len_digests)
             digests = self.parse_signatures_or_digests(raw_digests)
 
             # Certs
             certs = []
-            len_certs, = unpack('<I', signed_data.read(4))
+            len_certs = self.read_uint32_le(signed_data)
             start_certs = signed_data.tell()
             while signed_data.tell() < start_certs + len_certs:
-                len_cert, = unpack('<I', signed_data.read(4))
+                len_cert = self.read_uint32_le(signed_data)
                 cert = signed_data.read(len_cert)
                 certs.append(cert)
 
             # Additional attributes
-            len_attr, = unpack('<I', signed_data.read(4))
+            len_attr = self.read_uint32_le(signed_data)
             attributes = signed_data.read(len_attr)
 
             signed_data_object = APKV2SignedData()
@@ -1604,12 +1604,12 @@ class APK(object):
             signed_data_object.additional_attributes = attributes
 
             # Signatures
-            len_sigs, = unpack('<I', block.read(4))
+            len_sigs = self.read_uint32_le(block)
             raw_sigs = block.read(len_sigs)
             sigs = self.parse_signatures_or_digests(raw_sigs)
 
             # PublicKey
-            len_publickey, = unpack('<I', block.read(4))
+            len_publickey = self.read_uint32_le(block)
             publickey = block.read(len_publickey)
 
             signer = APKV2Signer()

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -1341,6 +1341,9 @@ class APK(object):
     def parse_signatures_or_digests(self, digest_bytes):
         """ Parse digests """
 
+        if not len(digest_bytes):
+            return []
+        
         digests = []
         block = io.BytesIO(digest_bytes)
 

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -1438,9 +1438,11 @@ class APK(object):
         Parse the V2 signing block and extract all features
         """
 
+        self._v3_signing_data = []
+
         # calling is_signed_v3 should also load the signature, if any
         if not self.is_signed_v3():
-            return []
+            return
 
         certificates = []
         block_bytes = self._v2_blocks[self._APK_SIG_KEY_V3_SIGNATURE]
@@ -1466,7 +1468,6 @@ class APK(object):
         size_sequence = self.read_uint32_le(block)
         assert size_sequence + 4 == len(block_bytes), "size of sequence and blocksize does not match"
         
-        self._v3_signing_data = []
         while block.tell() < len(block_bytes):
 
             off_signer = block.tell()
@@ -1540,10 +1541,11 @@ class APK(object):
         Parse the V2 signing block and extract all features
         """
 
+        self._v2_signing_data = []
 
         # calling is_signed_v2 should also load the signature
         if not self.is_signed_v2():
-            return []
+            return
 
         certificates = []
         block_bytes = self._v2_blocks[self._APK_SIG_KEY_V2_SIGNATURE]
@@ -1565,7 +1567,6 @@ class APK(object):
         size_sequence = self.read_uint32_le(block)
         assert size_sequence + 4 == len(block_bytes), "size of sequence and blocksize does not match"
 
-        self._v2_signing_data = []
         while block.tell() < len(block_bytes):
 
             off_signer = block.tell()

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -24,7 +24,7 @@ from xml.dom.pulldom import SAX2DOM
 from enum import Enum
 
 # Used for reading Certificates
-from asn1crypto import cms, x509
+from asn1crypto import cms, x509, keys
 
 NS_ANDROID_URI = 'http://schemas.android.com/apk/res/android'
 NS_ANDROID = '{http://schemas.android.com/apk/res/android}'
@@ -1620,6 +1620,36 @@ class APK(object):
 
             self._v2_signing_data.append(signer)
 
+    def get_public_keys_der_v3(self):
+        """
+        Return a list of DER coded X.509 public keys from the v3 signature block
+        """
+
+        if self._v3_signing_data == None:
+            self.parse_v3_signing_block()
+
+        public_keys = []
+
+        for signer in self._v3_signing_data:
+            public_keys.append(signer.public_key)
+
+        return public_keys
+
+    def get_public_keys_der_v2(self):
+        """
+        Return a list of DER coded X.509 public keys from the v3 signature block
+        """
+
+        if self._v2_signing_data == None:
+            self.parse_v2_signing_block()
+
+        public_keys = []
+
+        for signer in self._v2_signing_data:
+            public_keys.append(signer.public_key)
+
+        return public_keys
+
     def get_certificates_der_v3(self):
         """
         Return a list of DER coded X.509 certificates from the v3 signature block
@@ -1649,6 +1679,20 @@ class APK(object):
                 certs.append(cert)
 
         return certs
+
+    def get_public_keys_v3(self):
+        """
+        Return a list of :class:`asn1crypto.keys.PublicKeyInfo` which are found
+        in the v3 signing block.
+        """
+        return [ keys.PublicKeyInfo.load(pkey) for pkey in self.get_public_keys_der_v3()]
+
+    def get_public_keys_v2(self):
+        """
+        Return a list of :class:`asn1crypto.keys.PublicKeyInfo` which are found
+        in the v2 signing block.
+        """
+        return [ keys.PublicKeyInfo.load(pkey) for pkey in self.get_public_keys_der_v2()]
 
     def get_certificates_v3(self):
         """
@@ -1685,7 +1729,7 @@ class APK(object):
     def get_certificates(self):
         """
         Return a list of unique :class:`asn1crypto.x509.Certificate` which are found
-        in v1 and v2 signing
+        in v1, v2 and v3 signing
         Note that we simply extract all certificates regardless of the signer.
         Therefore this is just a list of all certificates found in all signers.
         """

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -1450,7 +1450,7 @@ class APK(object):
         certificates = []
         block_bytes = self._v2_blocks[self._APK_SIG_KEY_V3_SIGNATURE]
         block = io.BytesIO(block_bytes)
-        view = block.getbuffer()
+        view = block.getvalue()
 
         # V3 signature Block data format:
         #
@@ -1553,7 +1553,7 @@ class APK(object):
         certificates = []
         block_bytes = self._v2_blocks[self._APK_SIG_KEY_V2_SIGNATURE]
         block = io.BytesIO(block_bytes)
-        view = block.getbuffer()
+        view = block.getvalue()
         
         # V2 signature Block data format:
         #


### PR DESCRIPTION
Hi,

I've implemented the APK signature scheme v3 which was missing from androguard. I relied on the following sources for the implementation :

* https://source.android.com/security/apksigning/v3 : official documentation about APK V3 signing
* https://github.com/avast/apkverifier/blob/master/signingblock/schemev3.go : Go implementation of the APK V3 signing parser.

This is a pretty new scheme, so not many APK has them (it is backwards compatible with V2) but you can test it with Google Play's APK. I also took some liberty to refactor the internal code since the parsing is extremely similar between V2 and V3.

Anyway if you have remarks or questions, feel free to ask.

Cheers