### PR TITLE
resolve IDs directly from cmdline

### DIFF
--- a/androguard/cli/entry_points.py
+++ b/androguard/cli/entry_points.py
@@ -204,22 +204,12 @@ def arsc(input_,
             print("ID '{}' could not be parsed! have you supplied the correct hex ID?".format(id_))
             sys.exit(1)
 
-        package = None
-        resource = None
-        name = None
-        for p in arscobj.get_packages_names():
-            r, n, r_id = arscobj.get_id(p, i_id)
-            if r_id:
-                # found the resource in this package
-                package = p
-                resource = r
-                name = n
-                break
-        if not package:
+        name = arscobj.get_resource_xml_name(i_id)
+        if not name:
             print("Specified resource was not found!")
             sys.exit(1)
 
-        print("@{:08x} resolves to '@{}:{}/{}'".format(i_id, package, resource, name))
+        print("@{:08x} resolves to '{}'".format(i_id, name))
         print()
 
         # All the information is in the config.

--- a/androguard/cli/entry_points.py
+++ b/androguard/cli/entry_points.py
@@ -123,7 +123,7 @@ def axml(input_, output, file_, resource):
     help='Show only resources of the given type (default: public)',
 )
 @click.option(
-    '--id', '-i', 'id_',
+    '--id', 'id_',
     help="Resolve the given ID for the given locale and package. Provide the hex ID!"
 )
 @click.option(

--- a/androguard/cli/entry_points.py
+++ b/androguard/cli/entry_points.py
@@ -215,7 +215,7 @@ def arsc(input_,
         # All the information is in the config.
         # we simply need to get the actual value of the entry
         for config, entry in arscobj.get_res_configs(i_id):
-            print("{} = '{}'".format(config.get_config_name_friendly() if not config.is_default() else "<default>", entry.get_key_data()))
+            print("{} = '{}'".format(config.get_qualifier() if not config.is_default() else "<default>", entry.get_key_data()))
 
         sys.exit(0)
 

--- a/androguard/core/bytecodes/axml/__init__.py
+++ b/androguard/core/bytecodes/axml/__init__.py
@@ -1729,6 +1729,42 @@ class ARSCParser(object):
 
         return result
 
+    def get_resource_xml_name(self, r_id, package=None):
+        """
+        Returns the XML name for a resource, including the package name if package is None.
+        A full name might look like `@com.example:string/foobar`
+        Otherwise the name is only looked up in the specified package and is returned without
+        the package name.
+        The same example from about without the package name will read as `@string/foobar`.
+
+        If the ID could not be found, `None` is returned.
+
+        A description of the XML name can be found here:
+        https://developer.android.com/guide/topics/resources/providing-resources#ResourcesFromXml
+
+        :param r_id: numerical ID if the resource
+        :param package: package name
+        :return: XML name identifier
+        """
+        if package:
+            resource, name, i_id = self.get_id(package, r_id)
+            if not i_id:
+                return None
+            return "@{}/{}".format(resource, name)
+        else:
+            for p in self.get_packages_names():
+                r, n, i_id = self.get_id(p, r_id)
+                if r_id:
+                    # found the resource in this package
+                    package = p
+                    resource = r
+                    name = n
+                    break
+            if not package:
+                return None
+            else:
+                return "@{}:{}/{}".format(package, resource, name)
+
 
 class PackageContext(object):
     def __init__(self, current_package, stringpool_main, mTableStrings,
@@ -2034,6 +2070,9 @@ class ARSCResTableConfig(object):
             self.screenSizeDp = \
                 ((kwargs.pop('screenWidthDp', 0) & 0xffff) << 0) + \
                 ((kwargs.pop('screenHeightDp', 0) & 0xffff) << 16)
+
+            # TODO add this some day...
+            self.screenConfig2 = 0
 
             self.exceedingSize = 0
 

--- a/androguard/core/bytecodes/axml/__init__.py
+++ b/androguard/core/bytecodes/axml/__init__.py
@@ -1574,7 +1574,8 @@ class ARSCParser(object):
                 if i[2] == rid:
                     return i
         except KeyError:
-            return None, None, None
+            pass
+        return None, None, None
 
     class ResourceResolver(object):
         def __init__(self, android_resources, config=None):
@@ -1754,7 +1755,7 @@ class ARSCParser(object):
         else:
             for p in self.get_packages_names():
                 r, n, i_id = self.get_id(p, r_id)
-                if r_id:
+                if i_id:
                     # found the resource in this package
                     package = p
                     resource = r

--- a/tests/test_arsc.py
+++ b/tests/test_arsc.py
@@ -56,6 +56,18 @@ class ARSCTest(unittest.TestCase):
         self.assertEqual(e.find("string[@name='hello']").text, 'Hello World, TestActivity! kikoololmodif')
         self.assertEqual(e.find("string[@name='app_name']").text, 'TestsAndroguardApplication')
 
+    def testResourceNames(self):
+        """
+        Test if the resource name translation works
+        """
+        arsc = self.apk.get_android_resources()
+
+        self.assertEqual(arsc.get_resource_xml_name(0x7F040001), "@tests.androguard:string/app_name")
+        self.assertEqual(arsc.get_resource_xml_name(0x7F020000), "@tests.androguard:drawable/icon")
+
+        self.assertEqual(arsc.get_resource_xml_name(0x7F040001, 'tests.androguard'), "@string/app_name")
+        self.assertEqual(arsc.get_resource_xml_name(0x7F020000, 'tests.androguard'), "@drawable/icon")
+
     def testDifferentStringLocales(self):
         """
         Test if the resolving of different string locales works

--- a/tests/test_arsc.py
+++ b/tests/test_arsc.py
@@ -68,6 +68,11 @@ class ARSCTest(unittest.TestCase):
         self.assertEqual(arsc.get_resource_xml_name(0x7F040001, 'tests.androguard'), "@string/app_name")
         self.assertEqual(arsc.get_resource_xml_name(0x7F020000, 'tests.androguard'), "@drawable/icon")
 
+        # Also test non existing resources
+        self.assertIsNone(arsc.get_resource_xml_name(0xFFFFFFFF))
+        self.assertEqual(arsc.get_id('sdf', 0x7F040001), (None, None, None))
+        self.assertEqual(arsc.get_id('tests.androguard', 0xFFFFFFFF), (None, None, None))
+
     def testDifferentStringLocales(self):
         """
         Test if the resolving of different string locales works

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -133,6 +133,33 @@ class EntryPointsTest(unittest.TestCase):
         result = runner.invoke(entry_points.entry_point, arguments)
         assert result.exit_code == 1, arguments
 
+    def test_arsc_basic_id_resolve(self):
+        runner = CliRunner()
+        apk_path = resource_filename('androguard',
+                                     '../examples/dalvik/test/bin/'
+                                     'Test-debug.apk')
+        arguments = ['arsc', apk_path, '--id', '7F030000']
+        result = runner.invoke(entry_points.entry_point, arguments)
+        assert result.exit_code == 0, arguments
+
+    def test_arsc_error_id_resolve(self):
+        runner = CliRunner()
+        apk_path = resource_filename('androguard',
+                                     '../examples/dalvik/test/bin/'
+                                     'Test-debug.apk')
+        arguments = ['arsc', apk_path, '--id', 'sdlkfjsdlkf']
+        result = runner.invoke(entry_points.entry_point, arguments)
+        assert result.exit_code == 1, arguments
+
+    def test_arsc_error_id_not_resolve(self):
+        runner = CliRunner()
+        apk_path = resource_filename('androguard',
+                                     '../examples/dalvik/test/bin/'
+                                     'Test-debug.apk')
+        arguments = ['arsc', apk_path, '--id', '12345678']
+        result = runner.invoke(entry_points.entry_point, arguments)
+        assert result.exit_code == 1, arguments
+
     def test_arsc_error_no_arguments(self):
         runner = CliRunner()
         arguments = ['arsc']


### PR DESCRIPTION
```
$ androguard arsc  examples/tests/a2dp.Vol_137.apk --id 7F070058
@7f070058 resolves to '@a2dp.Vol:string/accessDescription'

<default> = 'Used to read notifications while connected to a device using A2DP Volume'
da = 'Bruges til at læse notifikationer der er forbundet til en enhed der bruger A2DP Volume'
ja = 'A2DP Volumeを使用しているデバイス接続中'
de = 'Wird verwendet, um Benachrichtigungen vorzulesen, wenn ein Gerät mit A2DP Volume verbunden ist'
el = 'Για χρήση ανάγνωσης ειδοποιήσεων ενώ είστε συνδεδεμένος σε συσκευή κάνοντας χρήση ήχου A2DP'
fr = 'Utilisé pour lire les notification lorsque connecté à un appareil utilisant A2DP Volume'
ru = 'Исп-ся для чтения уведомлений при соединении с уст-вом через A2DP Volume'
```