### PR TITLE
Update lib requirements to make androdd.py work properly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         # If you are installing on debian you can use python3-magic instead, which fulfills the dependency to file-magic
         'magic': ['file-magic'],
         'docs': ['sphinx', "sphinxcontrib-programoutput>0.8", 'sphinx_rtd_theme'],
-        'graphing': ['pydot'],
+        'graphing': ['pydot', 'GraphViz'],
         'tests': ['mock>=2.0', 'nose', 'codecov', 'coverage', 'nose-timer'],
     },
     setup_requires=['setuptools'],


### PR DESCRIPTION
I don't know if this is the right way to draft a PR - pardon me if I got it wrong!

Issue: androdd.py will fail for two different reasons

Environment: py 3.6, virtualenv, ubuntu 18.04

1.
```
Decompilation ... End
Dump Landroidx/core/net/ConnectivityManagerCompat; getNetworkInfoFromBroadcast (Landroid/net/ConnectivityManager; Landroid/content/Intent;)Landroid/net/NetworkInfo; ... jpg ... Traceback (most recent call last):
  File "/home/user/Documents/testvirtualenv/test/bin/androdd.py", line 63, in <module>
    args.jar, args.decompiler, args.format)
  File "/home/user/Documents/testvirtualenv/test/lib/python3.6/site-packages/androguard/cli/main.py", line 259, in export_apps_to_format
    method2format(filename + "." + form, form, None, buff)
  File "/home/user/Documents/testvirtualenv/test/lib/python3.6/site-packages/androguard/core/bytecode.py", line 368, in method2format
    import pydot
ModuleNotFoundError: No module named 'pydot'
```
I was installing via pip, so I guess pip got the required lib wrong. 
Anyway, after manually executing pip install pydot, I got another error:

2.
```
Decompilation ... End
Dump Landroidx/core/net/ConnectivityManagerCompat; getNetworkInfoFromBroadcast (Landroid/net/ConnectivityManager; Landroid/content/Intent;)Landroid/net/NetworkInfo; ... jpg ... Traceback (most recent call last):
  File "/home/a29988122/Documents/testvirtualenv/test/lib/python3.6/site-packages/pydot.py", line 1915, in create
    working_dir=tmp_dir,
  File "/home/a29988122/Documents/testvirtualenv/test/lib/python3.6/site-packages/pydot.py", line 136, in call_graphviz
    **kwargs
  File "/usr/lib/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1344, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'dot': 'dot'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/Documents/testvirtualenv/test/bin/androdd.py", line 63, in <module>
    args.jar, args.decompiler, args.format)
  File "/home/user/Documents/testvirtualenv/test/lib/python3.6/site-packages/androguard/cli/main.py", line 259, in export_apps_to_format
    method2format(filename + "." + form, form, None, buff)
  File "/home/user/Documents/testvirtualenv/test/lib/python3.6/site-packages/androguard/core/bytecode.py", line 393, in method2format
    getattr(g, "write_" + _format.lower())(output)
  File "/home/user/Documents/testvirtualenv/test/lib/python3.6/site-packages/pydot.py", line 1734, in new_method
    encoding=encoding)
  File "/home/user/Documents/testvirtualenv/test/lib/python3.6/site-packages/pydot.py", line 1817, in write
    s = self.create(prog, format, encoding=encoding)
  File "/home/user/Documents/testvirtualenv/test/lib/python3.6/site-packages/pydot.py", line 1922, in create
    raise OSError(*args)
FileNotFoundError: [Errno 2] "dot" not found in path.
```
Apparently, this was caused by another issue in pydot.
It ca be seen here: https://stackoverflow.com/questions/35177262/importerror-no-module-named-pydot-unable-to-import-pydot

So I guess add graphviz as a requirement lib is the solution to this?
Correct me if I'm wrong, 1st time doing PR! Thank you.