### PR TITLE
androauto.py got mistakenly removed from setup.py, readd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
     scripts=['androaxml.py',
              'androarsc.py',
              'androsign.py',
+             'androauto.py',
              'androdis.py',
              'androlyze.py',
              'androdd.py',


### PR DESCRIPTION
026d42777291b893238c5d63c5200dda803e123b seems to want to undo some previous
changes, but it also removed androauto.py from setup.py.