### PR TITLE
Re-adding certain functions in the AXMLParser

### DIFF
--- a/androguard/core/bytecodes/axml/__init__.py
+++ b/androguard/core/bytecodes/axml/__init__.py
@@ -728,6 +728,27 @@ class AXMLParser(object):
 
         return self.sb[self.m_name]
 
+    def getName(self):
+        """
+        Legacy only!
+        use :func:`~androguard.core.bytecodes.AXMLParser.name` instead
+        """
+        return self.name
+
+    def getText(self):
+        """
+        Legacy only!
+        use :func:`~androguard.core.bytecodes.AXMLParser.text` instead
+        """
+        return self.text
+
+    def getPrefix(self):
+        """
+        Legacy only!
+        use :func:`~androguard.core.bytecodes.AXMLParser.namespace` instead
+        """
+        return self.namespace
+
     def _get_attribute_offset(self, index):
         """
         Return the start inside the m_attributes array for a given attribute


### PR DESCRIPTION
In order to not break existing tools, some functions were re-added.
Note that still some functions are renamed or even removed due to
refactoring and reorganization of the parser.
As the method of resolving namespaces has changed, some methods do
not make any sense. Please check your projects!

Detailed changes between 3.2.1 and 3.3.0:

StringBlock: Made some functions private, as they are not used from
the outside.

Renamed functions:
* decode8(self, offset) --> _decode8
* decode16(self, offset) --> _decode16
* decode_bytes(self, data, encoding, str_len) --> _decode_bytes (and static)
* decodeLength(self, offset, sizeof_char) --> _decode_length

AXMLParser: renamed some functions, also removed many namespace
parsing functions.

Renamed functions:
* reset(self) --> _reset
* doNext(self) --> _do_next
* getPrefix(self) --> namespace, but was added again for legacy
* getName(self) --> name, but was added again for legacy
* getText(self) --> text, but was added again for legacy

Removed functions:
* getNamespacePrefix(self, pos)
* getNamespaceUri(self, pos)
* getXMLNS(self)
* getNamespaceCount(self, pos)
* getAttributeOffset(self, index)
* getAttributePrefix(self, index)
* getPrefixByUri(self, uri)

For a reference implementation on using namespaces, please see AXMLPrinter!

AXMLPrinter: changed the parsing behaviour to use lxml.etree directly

Renamed functions:
* getAttributeValue(self, index) --> _get_attribute_value

Removed functions:
* getPrefix(self, prefix)