### PR TITLE
Remove other magic implementations

### DIFF
--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -11,6 +11,11 @@ For Windows, we recommend using the Anaconda python 3.6.x package.
 Note that there is no PyQT5 for python 2.x! If you like to use the GUI, please
 use a newer version of python!
 
+.. warning::
+
+   The magic library might not work out of the box. If your magic library does not work,
+   please refer to the installation instructions of python-magic_.
+
 PIP
 ---
 
@@ -20,8 +25,9 @@ Just use
 .. code-block:: bash
 
     $ pip install -U androguard[magic,GUI]
-    
-to  install androguard.
+
+
+to  install androguard including the GUI and magic file type detection.
 In order to use features which use :code:`dot`, you need Graphviz_ installed.
 This is not a python dependency but a binary package! Please follow the installation instructions for GraphvizInstall_.
 
@@ -30,7 +36,7 @@ You can also make use of an `virtualenv`, to separate the installation from your
 .. code-block:: bash
 
     $ virtualenv venv-androguard
-    $ . venv-androguard/bin/activate
+    $ source venv-androguard/bin/activate
     $ pip install -U androguard[magic,GUI]
     
 pip should install all required packages too.
@@ -48,26 +54,38 @@ Use git to fetch the sources, then install it.
 Please install git and python on your own.
 Beware, that androguard requires python 2.7 or at least 3.4 to work.
 Pypy >= 5.9.0 should work as well but is not tested.
-On Windows, there might be some issues with the magic library.
-Usually the Anaconda suite works fine!
+
 
 .. code-block:: bash
 
     $ git clone --recursive https://github.com/androguard/androguard.git
     $ cd androguard
-    $ pip install .[magic]
-
-if you like to install the GUI as well, use
-
-.. code-block:: bash
-
+    $ virtualenv -p python3 venv-androguard
+    $ source venv-androguard/bin/activate
     $ pip install .[magic,GUI]
 
 The dependencies, defined in :code:`setup.py` will be automatically installed.
 
-If you are installing the libraries using :code:`pip`, make sure you download the correct packages.
-For example, there are a lot of implemenations of the :code:`magic` library.
-Get the one, that is shipped with the file command (See [Fine Free File Command](http://www.darwinsys.com/file/)) or use `filemagic`, which should work as well.
+For development purposes, you might want to install the extra dependecies for
+`docs` and `tests` as well:
+
+.. code-block:: bash
+
+    $ git clone --recursive https://github.com/androguard/androguard.git
+    $ cd androguard
+    $ virtualenv -p python3 venv-androguard
+    $ source venv-androguard/bin/activate
+    $ pip install -e .[magic,GUI,tests,docs]
+
+You can then create a local copy of the documentation:
+
+
+.. code-block:: bash
+
+   $ python3 setup.py build_sphinx
+
+Which is generated in :code:`build/sphinx/html`.
 
 .. _Graphviz: https://graphviz.org/
 .. _GraphvizInstall: https://graphviz.org/download/
+.. _python-magic: https://github.com/ahupp/python-magic/#installation

--- a/setup.py
+++ b/setup.py
@@ -85,12 +85,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'GUI': ["pyperclip", "PyQt5"],
-        # We support the following three magic packages:
-        # * filemagic from https://pypi.python.org/pypi/filemagic
-        # * file-magic from https://pypi.python.org/pypi/file-magic  (which is the "offical" one, and also in Debian)
-        # * python-magic from https://pypi.python.org/pypi/python-magic
-        # If you are installing on debian you can use python3-magic instead, which fulfills the dependency to file-magic
-        'magic': ['file-magic'],
+        'magic': ['python-magic>=0.4.15'],
         'docs': ['sphinx', "sphinxcontrib-programoutput>0.8", 'sphinx_rtd_theme'],
         'tests': ['mock>=2.0', 'nose', 'codecov', 'coverage', 'nose-timer'],
     },


### PR DESCRIPTION
This removes all magic implementation except the one of
python-magic.
This resolves two issues:
* resolves #439
* resolves #292

Note that the magic implementation for your operating system might
have issues. Please read the installation instructions of
python-magic: https://github.com/ahupp/python-magic/#installation