### PR TITLE
[RDY] Improving DEX parsing time

### DIFF
--- a/androguard/core/bytecode.py
+++ b/androguard/core/bytecode.py
@@ -593,60 +593,6 @@ def method2json_direct(mx):
     return json.dumps(d)
 
 
-class SV:
-
-    def __init__(self, size, buff):
-        self.__size = size
-        self.__value = unpack(self.__size, buff)[0]
-
-    def _get(self):
-        return pack(self.__size, self.__value)
-
-    def __str__(self):
-        return "0x%x" % self.__value
-
-    def __int__(self):
-        return self.__value
-
-    def get_value_buff(self):
-        return self._get()
-
-    def get_value(self):
-        return self.__value
-
-    def set_value(self, attr):
-        self.__value = attr
-
-
-class SVs:
-
-    def __init__(self, size, ntuple, buff):
-        self.__size = size
-
-        self.__value = ntuple._make(unpack(self.__size, buff))
-
-    def _get(self):
-        l = []
-        for i in self.__value._fields:
-            l.append(getattr(self.__value, i))
-        return pack(self.__size, *l)
-
-    def _export(self):
-        return [x for x in self.__value._fields]
-
-    def get_value_buff(self):
-        return self._get()
-
-    def get_value(self):
-        return self.__value
-
-    def set_value(self, attr):
-        self.__value = self.__value._replace(**attr)
-
-    def __str__(self):
-        return self.__value.__str__()
-
-
 def object_to_bytes(obj):
     """
     Convert a object to a bytearray or call get_raw() of the object
@@ -787,9 +733,6 @@ class BuffHandle:
         :param int off: starting offset
         :rtype: bytearray
         """
-        if isinstance(off, SV):
-            off = off.value
-
         return self.__buff[off:]
 
     def read(self, size):
@@ -800,9 +743,6 @@ class BuffHandle:
         :param int size: length of bytes to read
         :rtype: bytearray
         """
-        if isinstance(size, SV):
-            size = size.value
-
         buff = self.__buff[self.__idx:self.__idx + size]
         self.__idx += size
 

--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -1908,11 +1908,8 @@ class StringDataItem:
         string as 6 characters: \\ud853
         Valid surrogates are encoded as 32bit values, ie. \U00024f5c.
         """
-        s = mutf8.decode(self.data)
-        if len(s) != self.utf16_size:
-            raise ValueError("UTF16 Length does not match!")
         # log.debug("Decoding UTF16 string with IDX {}, utf16 length {} and hexdata '{}'.".format(self.offset, self.utf16_size, binascii.hexlify(self.data)))
-        return mutf8.patch_string(s)
+        return mutf8.decode_and_patch(self.data, self.utf16_size)
 
     def show(self):
         bytecode._PrintSubBanner("String Data Item")

--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -101,13 +101,18 @@ def read_null_terminated_string(f):
     :param f: file-like object
     :rtype: bytearray
     """
-    x = bytearray()
+    x = []
     while True:
-        z = f.read(1)
-        if ord(z) == 0:
-            return x
+        z = f.read(128)
+        if 0 in z:
+            s = z.split(b'\x00',1)
+            x.append(s[0])
+            idx = f.get_idx()
+            f.set_idx(idx - len(s[1]))
+            break
         else:
-            x.append(ord(z))
+            x.append(z)
+    return b''.join(x)
 
 
 def get_access_flags_string(value):

--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -199,11 +199,11 @@ def static_operand_instruction(instruction):
 
 
 def get_sbyte(buff):
-    return unpack('=b', bytearray(buff.read(1)))[0]
+    return unpack('=b', buff.read(1))[0]
 
 
 def get_byte(buff):
-    return unpack('=B', bytearray(buff.read(1)))[0]
+    return unpack('=B', buff.read(1))[0]
 
 
 def readuleb128(buff):

--- a/androguard/core/bytecodes/mutf8.py
+++ b/androguard/core/bytecodes/mutf8.py
@@ -56,6 +56,7 @@ def decode_and_patch(b, size):
     chr_array = [""] * size
 
     b = iter(b)
+    decoded_size = 0
 
     high_surrogate = None
     chr_index = 0
@@ -100,6 +101,10 @@ def decode_and_patch(b, size):
             else:
                 chr_array[chr_index] = chr(c)
             chr_index += 1
+        decoded_size += 1
+
+    if decoded_size != size:
+        raise ValueError("UTF16 Length does not match!")
 
     return "".join(chr_array)
 

--- a/androguard/core/bytecodes/mutf8.py
+++ b/androguard/core/bytecodes/mutf8.py
@@ -41,6 +41,69 @@ def decode(b):
     return res
 
 
+def decode_and_patch(b, size):
+    """
+    Decode bytes as MUTF-8
+    See https://docs.oracle.com/javase/6/docs/api/java/io/DataInput.html#modified-utf-8
+    for more information
+
+    Surrogates will be returned as two 16 bit characters.
+
+    :param b: bytes to decode
+    :rtype: unicode (py2), str (py3) of 16bit chars
+    :raises: UnicodeDecodeError if string is not decodable
+    """
+    chr_array = [""] * size
+
+    b = iter(b)
+
+    high_surrogate = None
+    chr_index = 0
+    for x in b:
+        n = 0
+        if x >> 7 == 0:
+            # Single char:
+            n = x & 0x7f
+        elif x >> 5 == 0b110:
+            # 2 byte Multichar
+            b2 = next(b)
+            if b2 >> 6 != 0b10:
+                raise UnicodeDecodeError("Second byte of 2 byte sequence does not looks right.")
+
+            n = (x & 0x1f) << 6 | b2 & 0x3f
+        elif x >> 4 == 0b1110:
+            # 3 byte Multichar
+            b2 = next(b)
+            b3 = next(b)
+            if b2 >> 6 != 0b10:
+                raise UnicodeDecodeError("Second byte of 3 byte sequence does not looks right.")
+            if b3 >> 6 != 0b10:
+                raise UnicodeDecodeError("Third byte of 3 byte sequence does not looks right.")
+
+            n = (x & 0xf) << 12 | (b2 & 0x3f) << 6 | b3 & 0x3f
+        else:
+            raise UnicodeDecodeError("Could not decode byte")
+        if high_surrogate is not None:
+            c = high_surrogate
+            if n and (n >> 10) == 0b110111:
+                chr_array[chr_index] = chr(((c & 0x3ff) << 10 | (n & 0x3ff)) + 0x10000)
+                chr_index += 1
+            else:
+                chr_array[chr_index] = "\\u{:04x}".format(c)
+            high_surrogate = None
+        else:
+            c = n
+            if (c >> 10) == 0b110110:
+                high_surrogate = c
+            elif (c >> 10) == 0b110111:
+                chr_array[chr_index] = "\\u{:04x}".format(c)
+            else:
+                chr_array[chr_index] = chr(c)
+            chr_index += 1
+
+    return "".join(chr_array)
+
+
 class PeekIterator:
     """
     A quick'n'dirty variant of an Iterator that has a special function

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -56,6 +56,12 @@ class StringTest(unittest.TestCase):
 
         self.assertEqual("\U00024f5c\U0001f64f\\ud83d\uacf0hello world\x00", mutf8.patch_string(mutf8.decode(b)))
 
+        self.assertEqual("hello world", mutf8.decode_and_patch(b"\x68\x65\x6c\x6c\x6f\x20\x77\x6f\x72\x6c\x64", 11))
+        self.assertEqual("\U00024f5c", mutf8.decode_and_patch(b"\xed\xa1\x93\xed\xbd\x9c",2))
+        self.assertEqual("\U0001f64f", mutf8.decode_and_patch(b"\xed\xa0\xbd\xed\xb9\x8f",2))
+        self.assertEqual("\\ud853", mutf8.decode_and_patch(b"\xed\xa1\x93", 1))
+        self.assertEqual("\U00024f5c\U0001f64f\\ud83d\uacf0hello world\x00", mutf8.decode_and_patch(b, 18))
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I did some changes regarding the mutf8 package. I've merged `patch_string` and `decode` in one function and it seems to be faster.

**Single test with `patch_string(decode(b))` :**
```
Runtime : 30.26204100s

              Name               | TotTime  |  Calls   | Source

patch_string                     | 7.212343 |   539456 | mutf8.py:97    
__next__                         | 4.871884 | 16732390 | mutf8.py:81    
decode                           | 3.503724 |   539456 | mutf8.py:25    
chr                              | 2.161444 | 16192935 | mutf8.py:6     
read                             | 1.811831 |  5206598 | bytecode.py:797   
<built-in method builtins.ord>   | 1.305763 | 37593719 |
read_null_terminated_string      | 1.109645 |   102793 | dvm.py:106   
<built-in method builtins.chr>   | 0.933014 | 16192935 |
<built-in method builtins.len>   | 0.672361 | 17288235 |
get_byte                         | 0.648539 |  1021791 | dvm.py:209   
get_string                       | 0.442125 |   500248 | dvm.py:7278  
get                              | 0.418365 |   539456 | dvm.py:1865  
<built-in method builtins.isinst | 0.375127 |  5339475 |
__init__                         | 0.369267 |    77741 | dvm.py:6715  
__init__                         | 0.271499 |    76293 | dvm.py:1464  
_load_elements                   | 0.246015 |    44096 | dvm.py:3368  
<built-in method _struct.unpack> | 0.235059 |  2400031 |
__init__                         | 0.205666 |   102793 | dvm.py:1817  
readuleb128                      | 0.201757 |   566395 | dvm.py:213   
<method 'append' of 'bytearray'  | 0.186060 |  2552524 |
```

**Single test with `decode_and_patch(b, size)` :**
```
Runtime : 15.95257000s

              Name               | TotTime  |  Calls   | Source

decode_and_patch                 | 5.373321 |   537811 | mutf8.py:44    
read                             | 1.909715 |  5206598 | bytecode.py:795   
read_null_terminated_string      | 1.079264 |   102793 | dvm.py:97    
<built-in method builtins.chr>   | 0.816411 | 16144640 |
get_byte                         | 0.713202 |  1021791 | dvm.py:200   
get_string                       | 0.473792 |   498603 | dvm.py:7274  
<built-in method builtins.isinst | 0.377888 |  5339444 |
__init__                         | 0.303388 |    77741 | dvm.py:6714  
get                              | 0.252122 |   537811 | dvm.py:1904  
<built-in method _struct.unpack> | 0.250697 |  2400031 |
__init__                         | 0.213221 |    77741 | dvm.py:6480  
__init__                         | 0.204559 |   102793 | dvm.py:1951  
readuleb128                      | 0.200434 |   566395 | dvm.py:204   
__init__                         | 0.184938 |    82413 | dvm.py:2817  
__init__                         | 0.182839 |   100931 | dvm.py:2418  
<built-in method builtins.ord>   | 0.181255 |  5207851 |
<method 'append' of 'bytearray'  | 0.181045 |  2552524 |
add_type_item                    | 0.173937 |       35 | dvm.py:7232  
<method 'join' of 'str' objects> | 0.159373 |   561045 |
_load_elements                   | 0.142084 |    44096 | dvm.py:3371
```

I'll see if I can find something for `read` and `read_null_terminated_string` methods.

Resolves : #684