### PR TITLE
Skip android API classes

### DIFF
--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -7952,14 +7952,20 @@ class DalvikVMFormat(bytecode.BuffHandle):
             self.classes_names = [i.get_name() for i in self.get_classes()]
         return self.classes_names
 
-    def get_classes(self):
+    def get_classes(self, skip_android_class=False):
         """
         Return all classes
 
         :rtype: a list of :class:`ClassDefItem` objects
         """
         if self.classes:
-            return self.classes.class_def
+            classes = self.classes.class_def
+            if skip_android_class:
+                api_candidates = ["Landroid/", "Landroidx/", "Lcom/android/internal/util", "Ldalvik/", "Ljava/", "Ljavax/", "Lorg/apache/",
+                                  "Lorg/json/", "Lorg/w3c/dom/", "Lorg/xml/sax", "Lorg/xmlpull/v1/", "Ljunit/"]
+                return [cls for cls in classes if not True in map(cls.get_name().startswith, api_candidates)]
+
+            return classes
         else:
             # There is a rare case that the DEX has no classes
             return []

--- a/tests/test_dex.py
+++ b/tests/test_dex.py
@@ -15,6 +15,10 @@ class DexTest(unittest.TestCase):
             self.assertTrue(classes)
             self.assertEqual(len(classes), 340)
 
+            classes = d.get_classes(skip_android_class=True)
+            self.assertTrue(classes)
+            self.assertEqual(len(classes), 29)
+
             methods = d.get_methods()
             self.assertTrue(methods)
             self.assertEqual(len(methods), 2600)


### PR DESCRIPTION
I suggest get_classes method should contain features what skip android API classes.  