### PR TITLE
Fix magic: Wrong exception caught

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -649,21 +649,25 @@ class APK:
             log.warning("It looks like you have the magic python package installed but not the magic library itself!")
             log.warning("Error from magic library: %s", e)
             log.warning("Please follow the installation instructions at https://github.com/ahupp/python-magic/#installation")
+            log.warning("You can also install the 'python-magic-bin' package on Windows and MacOS")
             return default
 
         try:
             # There are several implementations of magic,
             # unfortunately all called magic
             # We use this one: https://github.com/ahupp/python-magic/
+            # You can also use python-magic-bin on Windows or MacOS
             getattr(magic, "MagicException")
         except AttributeError:
             self.__no_magic = True
-            log.warning("Not the correct Magic library was found on your system. Please install python-magic!")
+            log.warning("Not the correct Magic library was found on your "
+                        "system. Please install python-magic or python-magic-bin!")
             return default
 
         try:
+            # 1024 byte are usually enough to test the magic
             ftype = magic.from_buffer(buffer[:1024])
-        except magic.MagicError as e:
+        except magic.MagicException as e:
             log.exception("Error getting the magic type: %s", e)
             return default
 

--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,11 @@ from androguard import __version__
 from setuptools import setup, find_packages
 
 
-# We do not support Python <3.4
-if sys.version_info < (3, 4):
+# We do not support Python <3.5 (lxml and pyqt5 are not supported as well)
+if sys.version_info < (3, 5):
     print("Unfortunately, your python version is not supported!\n"
-          "Please upgrade at least to Python 3.4!", file=sys.stderr)
+          "Please upgrade at least to Python 3.5!", file=sys.stderr)
     sys.exit(1)
-
-# PyQT5 is only available for python >=3.5
-if sys.version_info <= (3, 4):
-    print("PyQT5 is probably not available for your system, the GUI might not work!", file=sys.stderr)
 
 install_requires = [
                     'networkx>=1.11',
@@ -26,6 +22,13 @@ install_requires = [
                     'pydot>=1.4.1',
                     'ipython>=5.0.0',
                     ]
+
+# Find the right version for the magic package
+if sys.platform in ('darwin', 'win32'):
+    magic_package = 'python-magic-bin>=0.4.14'
+else:
+    magic_package = 'python-magic>=0.4.15'
+
 
 # TODO add the permission mapping generation at a better place!
 # from axplorer_to_androguard import generate_mappings
@@ -78,7 +81,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'GUI': ["pyperclip", "PyQt5"],
-        'magic': ['python-magic>=0.4.15'],
+        'magic': [magic_package],
         'docs': ['sphinx', "sphinxcontrib-programoutput>0.8", 'sphinx_rtd_theme'],
         'tests': ['mock>=2.0', 'nose', 'codecov', 'coverage', 'nose-timer'],
     },
@@ -88,7 +91,6 @@ setup(
                  'License :: OSI Approved :: Apache Software License',
                  'Programming Language :: Python',
                  'Programming Language :: Python :: 3',
-                 'Programming Language :: Python :: 3.4',
                  'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
                  'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
The correct exception is actually MagicException and not MagicError,
this was probably a relict of the old days.

Also removed support for python3.4, as other libraries we use do not
support it either.

resolves #726