### PR TITLE
Add the catchall handler to the end of handler list.

### DIFF
--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -432,13 +432,14 @@ def determineException(vm, m):
                  (try_value.get_insn_count() * 2) - 1]
 
             handler_catch = value[1]
-            if handler_catch.get_size() <= 0:
-                z.append(["Ljava/lang/Throwable;",
-                          handler_catch.get_catch_all_addr() * 2])
 
             for handler in handler_catch.get_handlers():
                 z.append([vm.get_cm_type(handler.get_type_idx()),
                           handler.get_addr() * 2])
+
+            if handler_catch.get_size() <= 0:
+                z.append(["Ljava/lang/Throwable;",
+                          handler_catch.get_catch_all_addr() * 2])
 
             exceptions.append(z)
 


### PR DESCRIPTION
The exception handler list is ordered, if the catchall handler exists, it should be the last one.