### PR TITLE
android:<id> fails getting app_icon id.

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -570,7 +570,9 @@ class APK:
             return None
 
         if app_icon.startswith("@"):
-            res_id = int(app_icon[1:], 16)
+            app_icon_id = app_icon[1:]
+            app_icon_id = app_icon_id.split(':')[-1]
+            res_id = int(app_icon_id, 16)
             candidates = res_parser.get_resolved_res_configs(res_id)
 
             app_icon = None


### PR DESCRIPTION
Getting a app_icon fails with:

errorinvalid literal for int() with base 16: 'android:01080411'

Example apk: bbc0b4a181171c1180d9f18763e9b0e91c929fa37cadae445abe0f4d4ac673d6