### PR TITLE
add Quark-Engine into Projects using Androguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ In alphabetical order
 * [Koodous](https://koodous.com)
 * [MobSF](https://github.com/MobSF/Mobile-Security-Framework-MobSF)
 * [qiew](https://github.com/mtivadar/qiew)
+* [Quark-Engine](https://github.com/quark-engine/quark-engine)
 * [Viper Framework](https://github.com/viper-framework/viper)
 * ... and many more!
 


### PR DESCRIPTION
Thank you very much for each androguard maintainer, we create the quark-engine based on androguard,  this is an Obfuscation-Neglect Android Malware Scoring System to against android malware.