### PR TITLE
fixs docstring in issue #796 by pyupgrade

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -1024,7 +1024,7 @@ class APK:
         ]
 
     def is_tag_matched(self, tag, **attribute_filter):
-        """
+        r"""
         Return true if the attributes matches in attribute filter.
 
         An attribute filter is a dictionary containing: {attribute_name: value}.


### PR DESCRIPTION
Fix depreaction warning due to invalid escape sequences in Python 3.7.