### PR TITLE
Add string casting to the cls.name

### DIFF
--- a/androguard/gui/helpers.py
+++ b/androguard/gui/helpers.py
@@ -5,7 +5,7 @@ log = logging.getLogger("androguard.gui")
 class Signature:
     def __init__(self, cls, method=None, descriptor=None):
         self.cls = cls
-        self.class_components = self.cls.name.strip('L').strip(';').split('/')
+        self.class_components = str(self.cls.name).strip('L').strip(';').split('/')
         self.class_path = self.class_components[:-1]
         self.class_name = self.class_components[-1]
         self.full_class_name = self.cls.name


### PR DESCRIPTION
The original line: 
`self.class_components` = `self.cls.name.strip('L').strip(';').split('/')`
give the following error during the open phase of several apk files:
**TypeError:`** a bytes-like object is required, not **`'str'**
The problem can be easily solved casting explicitly the cls.name to string before manipulate it.