### PR TITLE
Fix wrong return value of get_method_idx function

### DIFF
--- a/androguard/core/bytecodes/dvm.py
+++ b/androguard/core/bytecodes/dvm.py
@@ -969,7 +969,7 @@ class ParameterAnnotation:
 
         :rtype: int
         """
-        return self.get_method_idx
+        return self.method_idx
 
     def get_annotations_off(self):
         """


### PR DESCRIPTION
This should return self.method_idx, not a function itself