### PR TITLE
synchronized behaviour with documentation

### DIFF
--- a/androguard/cli/main.py
+++ b/androguard/cli/main.py
@@ -334,6 +334,7 @@ def androlyze_main(session, filename):
     from androguard.core.bytecodes.apk import APK
     from androguard.core.bytecodes.dvm import DalvikVMFormat
     from androguard.core.analysis.analysis import Analysis
+    from androguard.misc import AnalyzeAPK
 
     colorama.init()
 


### PR DESCRIPTION
The getting started guide does not work as expected without the import of AnalyzeAPK (see https://github.com/androguard/androguard/blob/master/docs/intro/gettingstarted.rst)

This commit fixes the interactive shell to be in line with the documentation.