### PR TITLE
Remove one level of indirection on basicblock.

### DIFF
--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -237,7 +237,7 @@ class BasicBlocks:
 
     def get_basic_block(self, idx):
         for i in self.bb:
-            if i.get_start() <= idx < i.get_end():
+            if i.start <= idx < i.end:
                 return i
         return None
 


### PR DESCRIPTION
This trivial change takes the `AnalyzeAPK` time for Facebook.apk (`https://www.facebook.com/android_upgrade`) from 15s to 11s.

This is an extremely expensive loop. The removal of two unnecessary function calls helps dramatically.