### PR TITLE
Add check for extension of output file in cg()

### DIFF
--- a/androguard/cli/entry_points.py
+++ b/androguard/cli/entry_points.py
@@ -319,6 +319,17 @@ def cg(output,
     \b
         $ androguard cg examples/tests/hello-world.apk
     """
+
+    extensions = ['gml', 'gexf', 'gpickle', 'graphml', 'yaml', 'net']
+    try:
+        extension = output.rsplit(".", 1)[1]
+    except IndexError:
+            extension = ""
+    if not extension in extensions:
+        print("Filename of the output file must have an extension in [{}]!"
+            .format(", ".join(extensions)))
+        sys.exit(0)
+
     androcg_main(verbose=verbose,
                  APK=apk,
                  classname=classname,


### PR DESCRIPTION
The title is explicit.

After I have tested the app, I have no explicit message when using `-o` argument without extension or with a bad one.
So I have a `IndexError` on https://github.com/androguard/androguard/blob/8d091cbb309c0c50bf239f805cc1e0931b8dcddc/androguard/cli/main.py#L122
