### PR TITLE
Quick fix for UnicodeDecodeError

### DIFF
--- a/androguard/core/api_specific_resources/__init__.py
+++ b/androguard/core/api_specific_resources/__init__.py
@@ -61,7 +61,7 @@ def load_permissions(apilevel, permtype='permissions'):
         log.warning("Requested API Level could not be found, using {} instead".format(lower_level))
         return load_permissions(lower_level, permtype)
 
-    with open(permissions_file, "r") as fp:
+    with open(permissions_file, "r", encoding='utf-8') as fp:
         return json.load(fp)[permtype]
 
 


### PR DESCRIPTION
Quick fix for UnicodeDecodeError.

    apk = APK(fn)
  File "C:\Data\bin\Python39\lib\site-packages\androguard\core\bytecodes\apk.py", line 294, in __init__
    self._apk_analysis()
  File "C:\bin\Python39\lib\site-packages\androguard\core\bytecodes\apk.py", line 369, in _apk_analysis
    self.permission_module = androconf.load_api_specific_resource_module(
  File "C:\bin\Python39\lib\site-packages\androguard\core\androconf.py", line 369, in load_api_specific_resource_module
    ret = loader[resource_name](api)
  File "C:\Data\bin\Python39\lib\site-packages\androguard\core\api_specific_resources\__init__.py", line 65, in load_permissions
    return json.load(fp)[permtype]
  File "C:\bin\Python39\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2 in position 39020: illegal multibyte sequence