### PR TITLE
Fix offset error while buffer not enough in BuffHandle::read.

### DIFF
--- a/androguard/core/bytecode.py
+++ b/androguard/core/bytecode.py
@@ -822,7 +822,7 @@ class BuffHandle:
         :rtype: bytearray
         """
         buff = self.__buff[self.__idx:self.__idx + size]
-        self.__idx += size
+        self.__idx += len(buff)
 
         return buff
 


### PR DESCRIPTION
**Bug Reproduce：**
dex file: parse a small dex(may be 1kb, one simple class)
**Bug Analysis:**
call stack: StringDataItem -> read_null_terminated_string -> f.read(128) -> BuffHandle::read
reason: If buffer size less 128, it will return all buffer while the idx is plused 128, so the result is unexpectlly.