### PR TITLE
Fix APK get_main_activity error and add get_application_name

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -617,6 +617,15 @@ class APK(object):
             return self.format_value(z.pop())
         return None
 
+    def get_application_name(self):
+        """
+        Return Application Name
+        """
+        try:
+            return self.get_element("application","name")
+        except:
+            return ""
+
     def get_activities(self):
         """
             Return the android:name attribute of all activities

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -603,8 +603,11 @@ class APK(object):
                     val = sitem.get(NS_ANDROID + "name")
                     if val == "android.intent.action.MAIN":
                         x.add(item.get(NS_ANDROID + "name"))
-
-                for sitem in item.findall(".//category"):
+                # for same appliction ,maybe more than 3 category ,so it should be only one and keep right
+                categories = item.findall(".//category")
+                if len(categories)>=2:
+                    continue
+                for sitem in categories:
                     val = sitem.get(NS_ANDROID + "name")
                     if val == "android.intent.category.LAUNCHER":
                         y.add(item.get(NS_ANDROID + "name"))


### PR DESCRIPTION
## get_main_activity may not work right

If `AndroidManifest.xml ` tag ` "android.intent.action.MAIN" ` activity has ` "android.intent.category.LAUNCHER"` more than 3 `category ` ,`APK` may return  random value of  MainActivity from get_main_activity. But we need to return main entrypoint not random main_activity.

Follow code
```python3

from androguard.core.bytecodes import apk

def test_axml_get_main_activity():
    path = "aaa.apk"

    with open(path,'rb') as f:
        test_apk= apk.APK(path,testzip=True)
        print(test_apk.get_main_activity())
        print(test_apk.get_application_name())

```

## add get_application_name
For some reason,maybe need return an application name for user, I have added it on `APK`

example  `https://drive.google.com/file/d/1Rap0e-z3vbiG0xbV0TbZ_Hn8uiNc6Shg/view?usp=sharing`

I need  to return main entrypoint activity `com.tencent.server.fore.DefaultAliasActivity` but sometime `get_main_activity` may return 
`"mainActivity": "com.tencent.server.fore.QuickLoadActivity"` ,so I have fix it.





