### PR TITLE
Get the main_activity with priority

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -1110,8 +1110,7 @@ class APK:
             good_main_activities = main_activities.intersection(self.get_activities())
             if good_main_activities:
                 return good_main_activities.pop()
-            elif main_activities:
-                return main_activities.pop()
+            return main_activities.pop()
         return None
 
     def get_activities(self):

--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -1103,8 +1103,15 @@ class APK:
         :rtype: str
         """
         activities = self.get_main_activities()
-        if len(activities) > 0:
+        if len(activities) == 1:
             return self._format_value(activities.pop())
+        elif len(activities) > 1:
+            main_activities = {self._format_value(ma) for ma in activities}
+            good_main_activities = main_activities.intersection(self.get_activities())
+            if good_main_activities:
+                return good_main_activities.pop()
+            elif main_activities:
+                return main_activities.pop()
         return None
 
     def get_activities(self):
@@ -1142,12 +1149,12 @@ class APK:
     def get_res_value(self, name):
         """
         Return the literal value with a resource id
-        :rtype: str 
+        :rtype: str
         """
 
         res_parser = self.get_android_resources()
         if not res_parser:
-            return name 
+            return name
 
         res_id = res_parser.parse_id(name)[0]
         try:
@@ -1158,7 +1165,7 @@ class APK:
             log.warning("Exception get resolved resource id: %s" % e)
             return name
 
-        return value 
+        return value
 
     def get_intent_filters(self, itemtype, name):
         """


### PR DESCRIPTION
Hi @adesnos ,



### Example1: [f7b5a968544abd32134401609a3dfc2fb61a61f019a90f5f8c41411168198d42](https://www.virustotal.com/gui/file/f7b5a968544abd32134401609a3dfc2fb61a61f019a90f5f8c41411168198d42/details):
There are some applications that have more than one main activity, some of these being activity aliases.
In these cases, it makes sense to prioritise the main activity that is not an activity-alias.
- **main_activity** extracted using androguard (py3): **com.google.android.youtube.app.honeycomb.Shell$HomeActivity** (an alias-activity)
But this app has a main_activity which is a activity: **com.google.android.youtube.app.honeycomb.Shell$HomeActivity**

### Example2: [d9c307b40bbb8849e668012b9a17645cf67ff5695efb7e22c4a747293db1f19d](https://www.virustotal.com/gui/file/d9c307b40bbb8849e668012b9a17645cf67ff5695efb7e22c4a747293db1f19d/details).
If there are only main activities, which are aliases of activities, return one of these.
- **main_activity**: **com.duolingo.app.LoginActivity** (alias of **com.duolingo.splash.LaunchActivity**).
**com.duolingo.splash.LaunchActivity** is not directly main_activity.


Should the target activity or alias be returned?