### PR TITLE
Fix AndroidMafest.xml parsing exceptions

### DIFF
--- a/androguard/core/bytecodes/axml/__init__.py
+++ b/androguard/core/bytecodes/axml/__init__.py
@@ -801,7 +801,7 @@ class AXMLParser:
 
         res = self.sb[name]
         # If the result is a (null) string, we need to look it up.
-        if not res:
+        if not res or res == ':':
             attr = self.m_resourceIDs[name]
             if attr in public.SYSTEM_RESOURCES['attributes']['inverse']:
                 res = 'android:' + public.SYSTEM_RESOURCES['attributes']['inverse'][attr]


### PR DESCRIPTION
There was a sample 0b612a3589be4975ff86d9c311d62cad which could not parse the AndroidManifest.xml correctly.

### Before:
```xml
...
[WARNING ] androguard.axml: Confused: name contains a unknown namespace prefix: '_:'. This is either a broken AXML file or some attempt to break stuff.
[WARNING ] androguard.axml: Name '_:' contains invalid characters!
[WARNING ] androguard.axml: Duplicate attribute '__'! Will overwrite!
[WARNING ] androguard.apk: XML Seems to be packed, operations on the AndroidManifest.xml might fail.
[INFO    ] androguard.apk: APK file was successfully validated!
<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="6" android:versionName="4.1.0" package="tv.xxx">
  <uses-sdk __="22"/>
  <uses-permission __="android.permission.INTERNET"/>
  <uses-permission __="android.permission.WAKE_LOCK"/>
  <uses-permission __="android.permission.SEND_SMS"/>
  <uses-permission __="android.permission.ACCESS_NETWORK_STATE"/>
  <uses-permission __="android.permission.ACCESS_WIFI_STATE"/>
  <uses-permission __="android.permission.RECEIVE_SMS"/>
  <uses-permission __="android.permission.READ_PHONE_STATE"/>
  <uses-permission __="android.permission.RECEIVE_BOOT_COMPLETED"/>
  <application __="true">
   ...
```

### After:
```xml
[INFO    ] androguard.axml: Name 'android:name' starts with 'android:' prefix but 'android' is a known prefix. Replacing prefix.
[INFO    ] androguard.axml: Name 'android:exported' starts with 'android:' prefix but 'android' is a known prefix. Replacing prefix.
[INFO    ] androguard.axml: Name 'android:multiprocess' starts with 'android:' prefix but 'android' is a known prefix. Replacing prefix.
[INFO    ] androguard.axml: Name 'android:authorities' starts with 'android:' prefix but 'android' is a known prefix. Replacing prefix.
[WARNING ] androguard.apk: XML Seems to be packed, operations on the AndroidManifest.xml might fail.
[INFO    ] androguard.apk: APK file was successfully validated!
<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="6" android:versionName="4.1.0" package="tv.xxx">
  <uses-sdk android:minSdkVersion="7" android:targetSdkVersion="22"/>
  <uses-permission android:name="android.permission.INTERNET"/>
  <uses-permission android:name="android.permission.WAKE_LOCK"/>
  <uses-permission android:name="android.permission.SEND_SMS"/>
  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
  <uses-permission android:name="android.permission.RECEIVE_SMS"/>
  <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
  <application android:theme="@7F0C00F4" android:label="Xxx" android:icon="@7F0A0000" android:name="android.support.v4.app.Application" android:allowBackup="false" android:supportsRtl="true">
....
```
