### PR TITLE
Fix ValueError when printing StringAnalysis object

### DIFF
--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -768,7 +768,7 @@ class StringAnalysis:
 
     def __str__(self):
         data = "XREFto for string %s in\n" % repr(self.get_value())
-        for ref_class, ref_method in self.xreffrom:
+        for ref_class, ref_method, _ in self.xreffrom:
             data += "{}:{}\n".format(ref_class.get_vm_class().get_name(), ref_method)
         return data
 


### PR DESCRIPTION
The `xreffrom` of a `StringAnalysis` object are stored in tuples with 3 members (class, method and offset). However, the `__str__` method of the `StringAnalysis` class ignores the offset which casuse a `ValueError: too many values to unpack (expected 2)` exception. This PR fixes that.

Note that with this fix, the offset is not displayed in the output, but that could easily be added if that is preferable.