### PR TITLE
Prioritize the tags with the namespace

### DIFF
--- a/androguard/core/bytecodes/apk.py
+++ b/androguard/core/bytecodes/apk.py
@@ -917,7 +917,7 @@ class APK:
         """
         tags = self.find_tags(tag_name, **attribute_filter)
         for tag in tags:
-            value = tag.get(attribute) or tag.get(self._ns(attribute))
+            value =  tag.get(self._ns(attribute)) or tag.get(attribute)
             if value is not None:
                 if format_value:
                     yield self._format_value(value)
@@ -1142,12 +1142,12 @@ class APK:
     def get_res_value(self, name):
         """
         Return the literal value with a resource id
-        :rtype: str 
+        :rtype: str
         """
 
         res_parser = self.get_android_resources()
         if not res_parser:
-            return name 
+            return name
 
         res_id = res_parser.parse_id(name)[0]
         try:
@@ -1158,7 +1158,7 @@ class APK:
             log.warning("Exception get resolved resource id: %s" % e)
             return name
 
-        return value 
+        return value
 
     def get_intent_filters(self, itemtype, name):
         """


### PR DESCRIPTION
Sample: [4c7d2912ba24e4bf1dab1175ee435f85ec223ac86967fc61a3dacbd1a97ee329](https://www.virustotal.com/gui/file/4c7d2912ba24e4bf1dab1175ee435f85ec223ac86967fc61a3dacbd1a97ee329)

```
<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="23" minSdkVersion="14" targetSdkVersion="23"/>
```

For this sample, the value 14 was being returned for the **minSdkVersion** attribute, since the value without namespace had precedence.

![min_sdk](https://user-images.githubusercontent.com/4050863/135451429-fcd92472-b4f6-48d1-a9c4-e1ee72b695d5.png)
