### PR TITLE
Error getting xrefs

### DIFF
--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -1525,7 +1525,7 @@ class Analysis:
                     idx_type = instruction.get_ref_kind()
                     # type_info is the string like 'Ljava/lang/Object;'
                     type_info = instruction.cm.vm.get_cm_type(idx_type).lstrip('[')
-                    if type_info[0] != b'L':
+                    if type_info[0] != 'L':
                         # Need to make sure, that we get class types and not other types
                         continue
 
@@ -1566,7 +1566,7 @@ class Analysis:
                         continue
 
                     class_info = method_info[0].lstrip('[')
-                    if class_info[0] != b'L':
+                    if class_info[0] != 'L':
                         # Need to make sure, that we get class types and not other types
                         # If another type, like int is used, we simply skip it.
                         continue


### PR DESCRIPTION
Bug on extracting xrefs, check of class fails because comparison is done with a byte character, while the index 0 from a string is a string in python3. In case other python version want to be supported, a cast can be applied to byte or to string.