### PR TITLE
Fix AXML parsing error with manipulated

### DIFF
--- a/androguard/core/axml/__init__.py
+++ b/androguard/core/axml/__init__.py
@@ -447,8 +447,9 @@ class AXMLParser:
             self._valid = False
             return
         
-        self.buff.seek(axml_header.header_size + header.size)
         self.sb = StringBlock(self.buff, header)
+        
+        self.buff.seek(axml_header.header_size + header.size)
 
         # Stores resource ID mappings, if any
         self.m_resourceIDs = []

--- a/androguard/core/axml/__init__.py
+++ b/androguard/core/axml/__init__.py
@@ -154,6 +154,10 @@ class StringBlock:
         if (size % 4) != 0:
             logger.warning("Size of strings is not aligned by four bytes.")
 
+        if self.stringCount * 4 + header.header_size != self.stringsOffset :
+            logger.warning("Offset of strings is not expected. Try fixing it")
+            buff.seek(8 + self.stringsOffset)
+
         self.m_charbuff = buff.read(size)
 
         if self.stylesOffset != 0 and self.styleCount != 0:
@@ -442,7 +446,8 @@ class AXMLParser:
             logger.error("This does not look like an AXML file. String chunk header size does not equal 28! header size = {}".format(header.header_size))
             self._valid = False
             return
-
+        
+        self.buff.seek(axml_header.header_size + header.size)
         self.sb = StringBlock(self.buff, header)
 
         # Stores resource ID mappings, if any


### PR DESCRIPTION
It may fix some issue with packed or obfuscated AndroidManifest.xml example, https://www.virustotal.com/gui/file/64275082cdec19c4e9d74efb9dfcaba133d1d2312e3670ad976750c9a77752cb