### PR TITLE
FIX? Ignore? multi disk ZIP error

### DIFF
--- a/androguard/core/apk/__init__.py
+++ b/androguard/core/apk/__init__.py
@@ -1721,9 +1721,9 @@ class APK:
 
                 # These things should not happen for APKs
                 if this_disk != 0:
-                    raise BrokenAPKError("Not sure what to do with multi disk ZIP!")
+                    log.warning("Not sure what to do with multi disk ZIP!")
                 if disk_central != 0:
-                    raise BrokenAPKError("Not sure what to do with multi disk ZIP!")
+                    log.warning("Not sure what to do with multi disk ZIP!")
                 break
             f.seek(-4, io.SEEK_CUR)
 

--- a/androguard/core/apk/__init__.py
+++ b/androguard/core/apk/__init__.py
@@ -1721,9 +1721,9 @@ class APK:
 
                 # These things should not happen for APKs
                 if this_disk != 0:
-                    log.warning("Not sure what to do with multi disk ZIP!")
+                    logger.warning("This is a multi disk ZIP! Attempting to process its signature anyway!")
                 if disk_central != 0:
-                    log.warning("Not sure what to do with multi disk ZIP!")
+                    logger.warning("This is a multi disk ZIP! Attempting to process its signature anyway!")
                 break
             f.seek(-4, io.SEEK_CUR)
 


### PR DESCRIPTION
Unless we have better solution for multi part zip, it would be better ignoring and pretending it is single zip file. Found that some malwares use this trick to interrupt automated analysis like below sample. https://www.virustotal.com/gui/file/2b9eb34b2d86e9119ada81f2c641086225c420d3439a3ca22e2a903ce8c2c937