### PR TITLE
employing apkInspector to tackle packers and common static evasion techniques

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ mutf8
 dataset
 frida
 loguru
+apkInspector>=1.1.7


### PR DESCRIPTION
This PR utilizes [apkInspector](https://github.com/erev0s/apkInspector) to tackle common packer techniques targeting the zip structure of APK files. Additionally I have added the code, under the same principles the [axml](https://github.com/erev0s/apkInspector/blob/main/apkInspector/axml.py) module of apkInspector works, where it tackles static analysis evasion techniques employed on the AndroidManifest.

Testing apkInspector and androguard (as well other tools) against known malware which employs static analysis evasion techniques, can be found [here](https://erev0s.com/blog/unmasking-evasive-threats-with-apkinspector/)

Tests related to the reliability of the tool can be found [here](https://github.com/erev0s/apkInspector/tree/main/tests/top_apps). Additionally, the `test_axml.py` in tests was run [successfully](https://i.imgur.com/rxfBuOT.png), but was not able to run the `test_apk.py`, as it seems there are some information missing from the repo. If required I can provide test cases with the modded apks I have created from [here](https://github.com/erev0s/apkInspector/tree/main/tests/res).

edit: [example apk](https://www.joesandbox.com/analysis/1344544/0/html)