### PR TITLE
update pyproject name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "androguard-p"
+name = "androguard"
 description = "Androguard is a full python tool to play with Android files."
 authors = ["desnos <desnos@t0t0.fr>"]
 version = "4.1"


### PR DESCRIPTION
As mentioned in https://github.com/androguard/androguard/pull/957 there were still two things left before being possible to streamline the publishing to PyPI
 - updating the name of the project in the pyproject.toml
 - and setup the api token for PyPI

Initially i thought that whoever from the owners would setup the API token for the PyPI would also update the name, but since this seems to be taking some time, I am doing this PR to solely change the name of the project in the pyproject.toml so there are no issues if someone tries to install through pip directly from the repo.

