### PR TITLE
fix bug from 03b841bf4175b0621c024a496fc064cbaeb81408

### DIFF
--- a/androguard/core/axml/__init__.py
+++ b/androguard/core/axml/__init__.py
@@ -120,8 +120,8 @@ class StringBlock:
         # The string offset is counted from the beginning of the string section
         self.stringsOffset = unpack('<I', buff.read(4))[0]
         # check if the stringCount is correct
-        if (self.stringsOffset - 28)/4 != self.stringCount:
-            self.stringCount = int((self.stringsOffset - 28)/4)
+        if (self.stringsOffset - (self.styleCount * 4 + 28)) / 4 != self.stringCount:
+            self.stringCount = int((self.stringsOffset - (self.styleCount * 4 + 28)) / 4)
 
         # style_pool_offset
         # The styles offset is counted as well from the beginning of the string section
@@ -157,10 +157,6 @@ class StringBlock:
 
         if (size % 4) != 0:
             logger.warning("Size of strings is not aligned by four bytes.")
-
-        if self.stringCount * 4 + header.header_size != self.stringsOffset :
-            logger.warning("Offset of strings is not expected. Try fixing it")
-            buff.seek(8 + self.stringsOffset)
 
         self.m_charbuff = buff.read(size)
 


### PR DESCRIPTION
Commit 03b841bf4175b0621c024a496fc064cbaeb81408 added a bug for some cases when getting the strings from the string pool from the resources.arcs. The bug was caused from line 163 changed in the current PR.

Besides that this snippet in lines 161-163 causing this bug for the resources.arcs it is also not necessary as the stringCount for the cases with packers is covered properly in lines 123-124 which I also updated to take into account the styleCount.

to test the difference you can use the `get_app_name()` in some apps