### PR TITLE
Fix maxSdkVersion warning in _get_permission_maxsdk method

### DIFF
--- a/androguard/core/apk/__init__.py
+++ b/androguard/core/apk/__init__.py
@@ -423,7 +423,7 @@ class APK:
         try:
             maxSdkVersion = int(self.get_value_from_tag(item, "maxSdkVersion"))
         except ValueError:
-            logger.warning(self.get_max_sdk_version() + 'is not a valid value for <uses-permission> maxSdkVersion')
+            logger.warning(str(maxSdkVersion) + ' is not a valid value for <uses-permission> maxSdkVersion')
         except TypeError:
             pass
         return maxSdkVersion


### PR DESCRIPTION
### Summary
This pull request addresses a potential issue in the `_get_permission_maxsdk` method within the Androguard APK module. The current implementation could lead to a `TypeError` when `maxSdkVersion` is `None`. The proposed fix converts `maxSdkVersion` to a string in the `logger.warning` call, ensuring that the warning message is correctly logged without causing a TypeError.

### Changes Made
- Modified the `_get_permission_maxsdk` method to handle the case where `maxSdkVersion` is `None`.

