### PR TITLE
Restore 'androguard cg' callgraph generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Quick installation:
 ~~~~
 pip install androguard
 ~~~~
+
+For visualizing callgraphs generated with 'androguard cg', install additional dependencies:
+~~~~
+apt-get install libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev libxcb-shape0-dev libxcb-xkb-dev
+~~~~
+
 > [!IMPORTANT]
 > Versions >= 4.0.0 are new releases after a long time, where the project has substantial differences from the previous stable version 3.3.5 from 2019. This means that certain functionalities have been removed. If you notice an issue with your project using tha latest version, please open up an [issue](https://github.com/androguard/androguard/issues).
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,6 @@ Quick installation:
 pip install androguard
 ~~~~
 
-For visualizing callgraphs generated with 'androguard cg', install additional dependencies:
-~~~~
-apt-get install libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev libxcb-shape0-dev libxcb-xkb-dev
-~~~~
-
 > [!IMPORTANT]
 > Versions >= 4.0.0 are new releases after a long time, where the project has substantial differences from the previous stable version 3.3.5 from 2019. This means that certain functionalities have been removed. If you notice an issue with your project using tha latest version, please open up an [issue](https://github.com/androguard/androguard/issues).
 

--- a/androguard/cli/cli.py
+++ b/androguard/cli/cli.py
@@ -540,11 +540,7 @@ def cg(
     #                      yaml=nx.write_yaml,
     #                      net=nx.write_pajek,
     #                      )
-    # for u,v,d in callgraph.edges(data=True):
-    #     print("edge")
-    #     print(u)
-    #     print(v)
-    #     print(d)
+
         
 
     if show:
@@ -584,20 +580,14 @@ def cg(
                                 labels={n: f"{n.get_class_name()} {n.name} {n.descriptor}"
                                         for n in callgraph.nodes})
 
-        # matplotlib
         print("Showing")
-        # plt.margins(x=0.4, y=0.4)
         # plt.savefig("graph.png", dpi=1000)
-
-        # plt.tight_layout()
-        # plt.figure(figsize=(20,14))
         plt.draw()
         plt.show()
 
     else:
         # TODO: save various format too
         pass
-    # end matplotlib
         
     # else:
     #     writer = output.rsplit(".", 1)[1]

--- a/androguard/cli/cli.py
+++ b/androguard/cli/cli.py
@@ -580,16 +580,13 @@ def cg(
             else:
                 internal.append(n)
 
-        print("Drawing nodes and edges")
         nx.draw_networkx_nodes(
             callgraph,
-            # node_size=100,
             pos=pos, node_color='r',
             nodelist=internal)
 
         nx.draw_networkx_nodes(
             callgraph,
-            # node_size=100,
             pos=pos,
             node_color='b',
             nodelist=external)
@@ -606,8 +603,6 @@ def cg(
                                 labels={n: f"{n.get_class_name()} {n.name} {n.descriptor}"
                                         for n in callgraph.nodes})
 
-        print("Showing")
-        # plt.savefig("graph.png", dpi=1000)
         plt.draw()
         plt.show()
 

--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -1811,16 +1811,6 @@ class Analysis:
                 for m in c.get_methods():
                     z = m.get_method()
 
-                    # logger.info(z.get_descriptor())
-                    # if 'TestInnerClass' in z.get_descriptor():
-                    #     logger.info(z.get_descriptor())
-                    # if isinstance(z, ExternalMethod):
-                    #     print('external method')
-                    #     print(f'is list: {isinstance(z.get_descriptor(), list)}')
-                    # else:
-                    #     print('internal method')
-                    #     print(f'is str: {isinstance(z.get_descriptor(), str)}')
-
                     # TODO is it even possible that an internal class has
                     # external methods? Maybe we should check for ExternalClass
                     # instead...

--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -522,9 +522,10 @@ class MethodAnalysis:
         (this method is called by another method)
 
         :param classobj: :class:`~ClassAnalysis`
-        :param methodobj:  :class:`~androguard.core.bytecodes.dvm.EncodedMethod`
+        :param methodobj: :class:`~MethodAnalysis`
         :param offset: integer where in the method the call happens
         """
+        logger.info(type(methodobj))
         self.xreffrom.add((classobj, methodobj, offset))
 
     def get_xref_from(self):
@@ -534,8 +535,8 @@ class MethodAnalysis:
 
         The list of tuples has the form:
         (:class:`~ClassAnalysis`,
-        :class:`~androguard.core.bytecodes.dvm.EncodedMethod` or
-        :class:`~ExternalMethod`, :class:`int`)
+        :class:`~MethodAnalysis`,
+        :class:`int`)
         """
         return self.xreffrom
 

--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -511,7 +511,7 @@ class MethodAnalysis:
         (this method calls another method)
 
         :param classobj: :class:`~ClassAnalysis`
-        :param methodobj:  :class:`~androguard.core.bytecodes.dvm.EncodedMethod`
+        :param methodobj:  :class:`~MethodAnalysis`
         :param offset: integer where in the method the call happens
         """
         self.xrefto.add((classobj, methodobj, offset))
@@ -546,8 +546,8 @@ class MethodAnalysis:
 
         The list of tuples has the form:
         (:class:`~ClassAnalysis`,
-        :class:`~androguard.core.bytecodes.dvm.EncodedMethod` or
-        :class:`~ExternalMethod`, :class:`int`)
+        :class:`~MethodAnalysis`,
+        :class:`int`)
         """
         return self.xrefto
 

--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -1933,8 +1933,6 @@ class Analysis:
 
             _add_node(CG, orig_method, entry_points)
 
-            # callee_method actually seems to be a MethodAnalysis, which is
-            # not consistent with the documentation of m.get_xref_to()
             for callee_class, callee_method, offset in m.get_xref_to():
                 _add_node(CG, callee_method.method, entry_points)
 

--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -1903,6 +1903,7 @@ class Analysis:
                     method,
                     external=is_external,
                     entrypoint=is_entry_point,
+                    methodname=method.get_name(),
                     descriptor=method.get_descriptor(),
                     accessflags=method.get_access_flags_string(),
                     classname=method.get_class_name()

--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -525,7 +525,6 @@ class MethodAnalysis:
         :param methodobj: :class:`~MethodAnalysis`
         :param offset: integer where in the method the call happens
         """
-        logger.info(type(methodobj))
         self.xreffrom.add((classobj, methodobj, offset))
 
     def get_xref_from(self):
@@ -696,11 +695,6 @@ class MethodAnalysis:
             data += "{}:{} @0x{:x}\n".format(ref_class.get_vm_class().get_name(), ref_method, offset)
 
         return data
-
-    # def __str__(self):
-    #     return "{}->{} {} [access_flags={}]\n".format(
-    #         self.get_class_name(), self.method.get_name(), self.get_descriptor(),
-    #         self.method.get_access_flags_string())
 
     def __repr__(self):
         return "<analysis.MethodAnalysis {}>".format(self.method)

--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -1814,6 +1814,9 @@ class Analysis:
                     # TODO is it even possible that an internal class has
                     # external methods? Maybe we should check for ExternalClass
                     # instead...
+                    # Above: Yes, it is possible.  Internal classes that inherit from
+                    # an External class and call inherited methods will show as
+                    # external calls
                     if no_external and isinstance(z, ExternalMethod):
                         continue
                     if re.match(methodname, z.get_name()) and \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,10 @@ dataset = "*"
 frida = "*"
 loguru = "*"
 apkInspector = ">=1.1.7"
-networkx = ">=3.2.1"
-PyQt5 = ">=5.15.10"
+matplotlib = "*"
+networkx = "*"
+PyQt5 = "*"
+pyyaml = "*"
 
 [tool.setuptools.package_data]
 "androguard.core.api_specific_resources" = ["aosp_permissions/*.json", "api_permission_mappings/*.json"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ apkInspector = ">=1.1.7"
 matplotlib = "*"
 networkx = "*"
 PyQt5 = "*"
+PyQt5-Qt5 = {version = "^5.15,!=5.15.11,!=5.15.12"}
 pyyaml = "*"
 
 [tool.setuptools.package_data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dataset = "*"
 frida = "*"
 loguru = "*"
 apkInspector = ">=1.1.7"
+networkx = ">=3.2.1"
+PyQt5 = ">=5.15.10"
 
 [tool.setuptools.package_data]
 "androguard.core.api_specific_resources" = ["aosp_permissions/*.json", "api_permission_mappings/*.json"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ dataset
 frida
 loguru
 apkInspector>=1.1.7
+networkx>=3.2.1
+PyQt5>=5.15.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,7 @@ dataset
 frida
 loguru
 apkInspector>=1.1.7
-networkx>=3.2.1
-PyQt5>=5.15.10
+matplotlib
+networkx
+PyQt5
+pyyaml

--- a/tests/test_callgraph.py
+++ b/tests/test_callgraph.py
@@ -1,0 +1,101 @@
+from androguard.misc import AnalyzeAPK
+from androguard.core.analysis.analysis import ExternalMethod
+
+import os
+import unittest
+
+test_dir = os.path.dirname(os.path.abspath(__file__))
+
+class TestCallgraph(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        test_apk_path = os.path.join(test_dir, 'data/APK/TestActivity.apk')
+        cls.a, cls.d, cls.dx = AnalyzeAPK(test_apk_path)
+
+    def _get_num_nodes(self, callgraph):
+        num_external = 0
+        num_internal = 0
+
+        for n in callgraph:
+            if isinstance(n, ExternalMethod):
+                num_external+=1
+            else:
+                num_internal+=1
+
+        return callgraph.number_of_nodes(), num_external, num_internal
+
+    def testCallgraphTotalNodesEdges(self):
+        """test callgraph generated with default parameter values"""
+        callgraph = self.dx.get_call_graph()
+
+        total_nodes, total_external_nodes, total_internal_nodes = self._get_num_nodes(callgraph)
+
+        # ensure total of internal and external nodes equals the total nodes
+        self.assertEqual(total_nodes, total_external_nodes + total_internal_nodes)
+
+        # total num nodes
+        self.assertEqual(total_nodes, 3600)
+
+        # num external nodes
+        self.assertEqual(total_external_nodes, 1000)
+
+        # num external nodes
+        self.assertEqual(total_internal_nodes, 2600)
+
+        # total num edges
+        self.assertEqual(callgraph.number_of_edges(), 4490)
+
+
+    def testCallgraphFilterClassname(self):
+        """test callgraph with classname filter parameter"""
+        callgraph = self.dx.get_call_graph(classname='Ltests/androguard/*')
+
+        total_nodes, total_external_nodes, total_internal_nodes = self._get_num_nodes(callgraph)
+        
+        self.assertEqual(total_nodes, 165)
+        self.assertEqual(total_external_nodes, 41)
+        self.assertEqual(total_internal_nodes, 124)
+
+        self.assertEqual(callgraph.number_of_edges(), 197)
+
+    def testCallgraphFilterMethodname(self):
+        """test callgraph with methodname filter parameter"""
+        callgraph = self.dx.get_call_graph(methodname='Test*')
+
+        total_nodes, total_external_nodes, total_internal_nodes = self._get_num_nodes(callgraph)
+        
+        self.assertEqual(total_nodes, 36)
+        self.assertEqual(total_external_nodes, 12)
+        self.assertEqual(total_internal_nodes, 24)
+        self.assertEqual(callgraph.number_of_edges(), 42)
+
+    def testCallgraphFilterDescriptor(self):
+        """test callgraph with descriptor filter parameter"""
+        callgraph = self.dx.get_call_graph(descriptor='\(LTestDefaultPackage;\sI\sI\sLTestDefaultPackage\$TestInnerClass;\)V')
+
+        total_nodes, total_external_nodes, total_internal_nodes = self._get_num_nodes(callgraph)
+        
+        self.assertEqual(total_nodes, 2)
+        self.assertEqual(total_external_nodes, 0)
+        self.assertEqual(total_internal_nodes, 2)
+        self.assertEqual(callgraph.number_of_edges(), 1)
+
+        # since this is a small graph, let's check some additional values
+
+        # get the source and destination node of the only edge
+        src_node, dst_node = list(callgraph.edges)[0]
+
+        # check source node
+        self.assertEqual(src_node.get_class_name(), 'LTestDefaultPackage$TestInnerClass;')
+        self.assertEqual(src_node.get_name(), '<init>')
+        self.assertEqual(src_node.get_access_flags_string(), 'synthetic constructor')
+        self.assertEqual(src_node.get_descriptor(), '(LTestDefaultPackage; I I LTestDefaultPackage$TestInnerClass;)V')
+
+        # check dest node
+        self.assertEqual(dst_node.get_class_name(), 'LTestDefaultPackage$TestInnerClass;')
+        self.assertEqual(dst_node.get_name(), '<init>')
+        self.assertEqual(dst_node.get_access_flags_string(), 'private constructor')
+        self.assertEqual(dst_node.get_descriptor(), '(LTestDefaultPackage; I I)V')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Readded several dependencies, such as networkx, matplotlib, pyyaml, and pyqt5 to generate and render callgraphs
- Readded previous get_call_graph() function and made a few fixes
- fixed some docstring inaccuracies with MethodAnalysis xref_from/to
- Can export callgraphs to gml, gexf, graphml, and net (pajek), **but not gpickel or yaml because there are embedded attributes that are not serializable in EncodedMethod objects (BufferedReader in EncodedMethod.buff)**. 

Tested with the following commands:

```bash
androguard --verbose cg --show --classname "Ltests/androguard/*" ~/projects/androguard/tests/data/APK/TestActivity.apk
```

![ex1](https://github.com/androguard/androguard/assets/5570335/c33e7951-2b5c-4c45-8cd7-a4f003204cd7)

```bash
androguard --verbose cg --show --methodname "Test*" ~/projects/androguard/tests/data/APK/TestActivity.apk
```

![ex2](https://github.com/androguard/androguard/assets/5570335/e6304182-5499-464d-91ee-577536361c94)

```bash
androguard --verbose cg --show --descriptor '\(LTestDefaultPackage;\sI\sI\sLTestDefaultPackage\$TestInnerClass;\)V' ~/projects/androguard/tests/data/APK/TestActivity.apk
```

![ex3](https://github.com/androguard/androguard/assets/5570335/95b39a7e-702d-494c-b605-e700a0a41699)
