### PR TITLE
stricter regex to capture "official" classes.dex files

### DIFF
--- a/androguard/core/apk/__init__.py
+++ b/androguard/core/apk/__init__.py
@@ -811,7 +811,7 @@ class APK:
 
         :rtype: a list of str
         """
-        dexre = re.compile(r"classes(\d*).dex")
+        dexre = re.compile(r"^classes(\d*).dex$")
         return filter(lambda x: dexre.match(x), self.get_files())
 
     def get_all_dex(self):


### PR DESCRIPTION
In some cases [self.get_files](https://github.com/androguard/androguard/blob/9e7f13a042356fe92ca0b23bd0a96caf77adfbc5/androguard/core/apk/__init__.py#L628) returns a file name such as classes.dex/sample.png. To avoid capturing such file names use strict regex `dexre = re.compile(r"^classes(\d*).dex$")`

Sample: 
[infected.zip](https://github.com/androguard/androguard/files/13810008/infected.zip) (password: infected)

Running:
```
from androguard.misc import AnalyzeAPK
from androguard.util import set_log

set_log("ERROR")
a,d,x = AnalyzeAPK("./63629c8dce75311526ef11e8a9f410ff51d8ae709df3de4aaf16887d8f056d17")
```
will result in 
```
Traceback (most recent call last):
  File "/tmp/t.py", line 5, in <module>
    a,d,x = AnalyzeAPK("./63629c8dce75311526ef11e8a9f410ff51d8ae709df3de4aaf16887d8f056d17")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/androguard/androguard/misc.py", line 64, in AnalyzeAPK
    df = dex.DEX(dex_bytes, using_api=a.get_target_sdk_version())
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/androguard/androguard/core/dex/__init__.py", line 7669, in __init__
    self._load(buff)
  File "/tmp/androguard/androguard/core/dex/__init__.py", line 7675, in _load
    self.header = HeaderItem(0, self.raw, self.CM)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/androguard/androguard/core/dex/__init__.py", line 483, in __init__
    cm.packer = DalvikPacker(self.endian_tag)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/androguard/androguard/core/dex/__init__.py", line 7617, in __init__
    raise ValueError("This is not a DEX file! Wrong endian tag: '0x{:08x}'".format(endian_tag))
ValueError: This is not a DEX file! Wrong endian tag: '0x00000e6c
```
[get_dex_names](https://github.com/androguard/androguard/blob/9e7f13a042356fe92ca0b23bd0a96caf77adfbc5/androguard/core/apk/__init__.py#L806) returns following filename:
`classes.dex/drawable-xxxhdpi/abc_btn_switch_to_on_mtrl_00001.9.png` Since it's a png file and androguard tries to extract endianness [first](https://github.com/androguard/androguard/blob/9e7f13a042356fe92ca0b23bd0a96caf77adfbc5/androguard/core/dex/__init__.py#L482) then check [dex magic bytes](https://github.com/androguard/androguard/blob/9e7f13a042356fe92ca0b23bd0a96caf77adfbc5/androguard/core/dex/__init__.py#L512) analysis simply fails before checking if its a dex file or not. 
