### PR TITLE
Added error handling for ResParserError

### DIFF
--- a/androguard/core/axml/__init__.py
+++ b/androguard/core/axml/__init__.py
@@ -2333,16 +2333,18 @@ class ARSCResTypeSpec:
         self.id = unpack('<B', buff.read(1))[0]
         self.res0 = unpack('<B', buff.read(1))[0]
         self.res1 = unpack('<H', buff.read(2))[0]
-        if self.res0 != 0:
-            raise ResParserError("res0 must be zero!")
-        if self.res1 != 0:
-            raise ResParserError("res1 must be zero!")
-        self.entryCount = unpack('<I', buff.read(4))[0]
+        try:
+            if self.res0 != 0:
+                raise ResParserError("res0 must be zero!")
+            if self.res1 != 0:
+                raise ResParserError("res1 must be zero!")
+            self.entryCount = unpack('<I', buff.read(4))[0]
 
-        self.typespec_entries = []
-        for i in range(0, self.entryCount):
-            self.typespec_entries.append(unpack('<I', buff.read(4))[0])
-
+            self.typespec_entries = []
+            for i in range(0, self.entryCount):
+                self.typespec_entries.append(unpack('<I', buff.read(4))[0])
+        except ResParserError as e:
+            logger.warning(e)
 
 class ARSCResType:
     """
@@ -2935,11 +2937,14 @@ class ARSCResStringPoolRef:
 
         self.size, = unpack("<H", buff.read(2))
         self.res0, = unpack("<B", buff.read(1))
-        if self.res0 != 0:
-            raise ResParserError("res0 must be always zero!")
-        self.data_type = unpack('<B', buff.read(1))[0]
-        # data is interpreted according to data_type
-        self.data = unpack('<I', buff.read(4))[0]
+        try:
+            if self.res0 != 0:
+                raise ResParserError("res0 must be always zero!")
+            self.data_type = unpack('<B', buff.read(1))[0]
+            # data is interpreted according to data_type
+            self.data = unpack('<I', buff.read(4))[0]
+        except ResParserError as e:
+            logger.warning(e)
 
     def get_data_value(self):
         return self.parent.stringpool_main.getString(self.data)


### PR DESCRIPTION
Androguard halts the parsing of resources if it encounters specific resource types (RES_TABLE_TYPE_SPEC_TYPE ) where the res1 and res0 fields are not both set to zero. In this PR I've implemented error handling measures to ensure continuation of the processing. 

This issue became apparent to me as I worked on parsing samples from the following apps:

- 1100f090f0c1d2d09940d6e9887da58fd15ae7d7eb3a064761f09d5ded189bf4 (com.airbnb.android, version  name 24.10) 
- 4e4396a7fd6d8b3d1bb77c6004d6845d035ce58bba0ce5a6a01962e6069cd480 (com.facebook.orca, version name 447.1.0.45.106)