### PR TITLE
function to return android:name attribute of <meta-data> entries

### DIFF
--- a/androguard/core/apk/__init__.py
+++ b/androguard/core/apk/__init__.py
@@ -1115,6 +1115,14 @@ class APK:
         """
         return list(self.get_all_attribute_value("provider", "name"))
 
+    def get_meta_data_names(self, apk):
+        """
+        Return the android:name attribute of <meta-data> entries.
+
+        :rtype: a list of str
+        """
+        return list(self.get_all_attribute_value("meta-data", "name"))
+
     def get_res_value(self, name):
         """
         Return the literal value with a resource id


### PR DESCRIPTION
This is useful for discovering whether an app has any API Keys configured, e.g.:

https://developers.google.com/maps/documentation/android/start#get_an_android_certificate_and_the_google_maps_api_key
```xml
 <meta-data
        android:name="com.google.android.maps.v2.API_KEY"
        android:value="MY_KEY" />
```