### PR TITLE
[bugfix] Remove spaces from nsmap

### DIFF
--- a/androguard/core/axml/__init__.py
+++ b/androguard/core/axml/__init__.py
@@ -728,7 +728,7 @@ class AXMLParser:
             # Solve 2) & 4) by not including
             if s_uri != "" and s_prefix != "":
                 # solve 1) by using the last one in the list
-                NSMAP[s_prefix] = s_uri
+                NSMAP[s_prefix] = s_uri.strip()
 
         return NSMAP
 


### PR DESCRIPTION
### Current behaviour:

If manifest contains a space in `xmlns` attributes, APK can be installed without issue, but pyaxmlparser fails.
```
<manifest 
	xmlns:android="http://schemas.android.com/apk/res/android" 
	xmlns:tools="http://schemas.android.com/tools "
```

```
ValueError: Invalid namespace URI 'http://schemas.android.com/tools '
```

---
### Analysis 

```
>>> etree.Element("manifest", nsmap={"tools": "http://schemas.android.com/tools"})
<Element manifest at 0x1226f1600>

>>> etree.Element("manifest", nsmap={"tools": "http://schemas.android.com/tools "})
etree.Element("manifest", nsmap={"tools": "http://schemas.android.com/tools "})
File src/lxml/etree.pyx:3022, in lxml.etree.Element()
File src/lxml/apihelpers.pxi:131, in lxml.etree._makeElement()
File src/lxml/apihelpers.pxi:118, in lxml.etree._makeElement()
File src/lxml/apihelpers.pxi:215, in lxml.etree._setNodeNamespaces()
File src/lxml/apihelpers.pxi:1755, in lxml.etree._uriValidOrRaise()
ValueError: Invalid namespace URI 'http://schemas.android.com/tools '
```

There is a `recover` option in lxml to make the parser less strict:

```
from io import StringIO

attrs = [f"xmlns:{k}=\"{v}\"" for k,v in nsmap.items()]
manifest_str = f"<manifest {' '.join(attrs)} />"
tree = etree.parse(StringIO(manifest_str), magical_parser)
elem = tree.getroot()

>>> elem
<Element manifest at 0x11c04ca00>
```
This implementation is not clean and can't be used. There is another way to create `Element` directly, but it is not taking the parser passed:

```
magical_parser = etree.XMLParser(encoding='utf-8', recover=True)
elem = magical_parser.makeelement("manifest", nsmap=nsmap)

etree.Element("manifest", nsmap={"tools": "http://schemas.android.com/tools "})
File src/lxml/etree.pyx:3022, in lxml.etree.Element()
File src/lxml/apihelpers.pxi:131, in lxml.etree._makeElement()
File src/lxml/apihelpers.pxi:118, in lxml.etree._makeElement()
File src/lxml/apihelpers.pxi:215, in lxml.etree._setNodeNamespaces()
File src/lxml/apihelpers.pxi:1755, in lxml.etree._uriValidOrRaise()
ValueError: Invalid namespace URI 'http://schemas.android.com/tools '
```

So changing the way we create `Element` is currently not possible, better approach would be to send the cleaned nsmap itself.

---
### Changelog
- [x] Remove spaces from nsmap values
- [x] Add tests for `AXMLParser.nsmap` for this bug scenario



See more details in: https://github.com/appknox/pyaxmlparser/pull/64