### PR TITLE
make get_apkid() return versionCode as an integer

### DIFF
--- a/androguard/core/apk/__init__.py
+++ b/androguard/core/apk/__init__.py
@@ -2179,9 +2179,9 @@ def get_apkid(apkfile):
                     appid = value
                 elif versionCode is None and name == 'versionCode':
                     if value.startswith('0x'):
-                        versionCode = str(int(value, 16))
+                        versionCode = int(value, 16)
                     else:
-                        versionCode = value
+                        versionCode = int(value)
                 elif versionName is None and name == 'versionName':
                     versionName = value
 


### PR DESCRIPTION
`versionCode` is strictly defined to be an integer, any other type would be an error.  So `get_apkid()` should return `versionCode` as an integer or fail trying.