### PR TITLE
address pyqt5-qt5 inconsistencies by adding markers for MacOS ARM targets 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,13 @@ apkInspector = ">=1.1.7"
 matplotlib = "*"
 networkx = "*"
 PyQt5 = "*"
-PyQt5-Qt5 = {version = "5.15.2"}
+# address inconsistencies with pyqt5-qt5 binary release files
+# > 5.15.2 exclusively contains releases for macosx
+# 5.15.2 contains release for all, but not arm64 macosx
+PyQt5-Qt5 = [
+    {version = "*", markers = "sys_platform == 'darwin'"},
+    {version = "5.15.2", markers = "sys_platform != 'darwin'"}
+]
 pyyaml = "*"
 
 [tool.setuptools.package_data]


### PR DESCRIPTION
Fixes https://github.com/androguard/androguard/issues/1027 and https://github.com/androguard/androguard/issues/1018

