### PR TITLE
Correct attribute name to be the same used by Android

### DIFF
--- a/androguard/core/axml/__init__.py
+++ b/androguard/core/axml/__init__.py
@@ -380,6 +380,7 @@ class AXMLParser:
         self.axml_tampered = False
         self.buff = io.BufferedReader(io.BytesIO(raw_buff))
         self.buff_size = self.buff.raw.getbuffer().nbytes
+        self.packerwarning = False
 
         # Minimum is a single ARSCHeader, which would be a strange edge case...
         if self.buff_size < 8:
@@ -824,7 +825,10 @@ class AXMLParser:
         if name <= len(self.m_resourceIDs):
             attr = self.m_resourceIDs[name]
             if attr in public.SYSTEM_RESOURCES['attributes']['inverse']:
-                res = 'android:' + public.SYSTEM_RESOURCES['attributes']['inverse'][attr]
+                res = public.SYSTEM_RESOURCES['attributes']['inverse'][attr].replace("_",
+                                                                               ":")
+                if res != self.sb[name]:
+                    self.packerwarning = True
         
         if not res or res == ":":
             # Attach the HEX Number, so for multiple missing attributes we do not run
@@ -1047,7 +1051,7 @@ class AXMLPrinter:
 
         :returns: True if packer detected, False otherwise
         """
-        return self.packerwarning
+        return self.packerwarning or self.axml.packerwarning
 
     def _get_attribute_value(self, index):
         """

--- a/androguard/core/axml/__init__.py
+++ b/androguard/core/axml/__init__.py
@@ -821,14 +821,15 @@ class AXMLParser:
 
         res = self.sb[name]
         # If the result is a (null) string, we need to look it up.
-        if not res or res == ":":
+        if name <= len(self.m_resourceIDs):
             attr = self.m_resourceIDs[name]
             if attr in public.SYSTEM_RESOURCES['attributes']['inverse']:
                 res = 'android:' + public.SYSTEM_RESOURCES['attributes']['inverse'][attr]
-            else:
-                # Attach the HEX Number, so for multiple missing attributes we do not run
-                # into problems.
-                res = 'android:UNKNOWN_SYSTEM_ATTRIBUTE_{:08x}'.format(attr)
+        
+        if not res or res == ":":
+            # Attach the HEX Number, so for multiple missing attributes we do not run
+            # into problems.
+            res = 'android:UNKNOWN_SYSTEM_ATTRIBUTE_{:08x}'.format(attr)
         return res
 
     def getAttributeValueType(self, index):


### PR DESCRIPTION
Related with #953

**Changes**

Find a way to keep all information about AndroidManifest, I didnt find a file with issue mention in #953 there so if a sample is available it could be very nice, but normally it should not affect the number of information provided by the AndroidManifest.

Please don't merge it without review and test with the file issue. I let @danielgf3 answer about that. 
