### PR TITLE
Use get_encoded_methods() when decompiling

### DIFF
--- a/androguard/cli/cli.py
+++ b/androguard/cli/cli.py
@@ -256,6 +256,7 @@ def arsc(input_,
     '--format', '-f', 'format_',
     help='Additionally write control flow graphs for each method, specify '
          'the format for example png, jpg, raw (write dot file), ...',
+    type=click.Choice(['png', 'jpg', 'raw'])
 )
 @click.option(
     '--jar', '-j',

--- a/androguard/cli/main.py
+++ b/androguard/cli/main.py
@@ -144,7 +144,7 @@ def export_apps_to_format(filename,
             shutil.move(filenamejar, os.path.join(output, "classes.jar"))
             print("End")
 
-        for method in vm.get_methods():
+        for method in vm.get_encoded_methods():
             if methods_filter_expr:
                 msig = "{}{}{}".format(method.get_class_name(), method.get_name(),
                                        method.get_descriptor())

--- a/androguard/core/bytecode.py
+++ b/androguard/core/bytecode.py
@@ -416,7 +416,7 @@ def method2format(output, _format="png", mx=None, raw=None):
     :param androguard.core.analysis.analysis.MethodAnalysis mx: specify the MethodAnalysis object
     :param dict raw: use directly a dot raw buffer if None
     """
-    # pydot is optional!
+    # pydot is optional, it's only needed for png, jpg formats
     import pydot
 
     if raw:
@@ -465,9 +465,12 @@ def method2format(output, _format="png", mx=None, raw=None):
             logger.warning("The graph generated for '{}' has too many subgraphs! "
                        "Only plotting the first one.".format(output))
         for g in d:
-            getattr(g, "write_" + _format.lower())(output)
-            break
-
+            try:
+                getattr(g, "write_" + _format.lower())(output)
+                break
+            except FileNotFoundError:
+                logger.error("Could not write graph image, ensure graphviz is installed!")
+                raise
 
 def method2png(output, mx, raw=False):
     """

--- a/tests/test_callgraph.py
+++ b/tests/test_callgraph.py
@@ -39,7 +39,7 @@ class TestCallgraph(unittest.TestCase):
         # num external nodes
         self.assertEqual(total_external_nodes, 1000)
 
-        # num external nodes
+        # num internal nodes
         self.assertEqual(total_internal_nodes, 2600)
 
         # total num edges

--- a/tests/test_cli_decompile.py
+++ b/tests/test_cli_decompile.py
@@ -1,0 +1,37 @@
+from androguard.cli.main import export_apps_to_format
+from androguard import session
+
+import os
+import shutil
+import unittest
+
+test_dir = os.path.dirname(os.path.abspath(__file__))
+
+class TestCLIDecompile(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        test_testactivity_apk_path = os.path.join(test_dir, 'data/APK/TestActivity.apk')
+        cls.s = session.Session()
+        with open(test_testactivity_apk_path, "rb") as fd:
+            cls.s.add(test_testactivity_apk_path, fd.read())
+
+    def testDecompileDefaults(self):
+        """test decompile command using default cli settings"""
+        export_apps_to_format(
+            None,
+            self.s,
+            os.path.join(test_dir,'tmp_TestActivity_decompilation'),
+            None,
+            False,
+            None,
+            None)
+        
+    @classmethod
+    def tearDownClass(cls):
+        decomp_dir = os.path.join(test_dir, 'tmp_TestActivity_decompilation')
+        if os.path.exists(decomp_dir):
+            shutil.rmtree(decomp_dir)
+
+        
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Fix https://github.com/androguard/androguard/issues/1033
* Create basic unit test for decompilation