### PR TITLE
Fix #1031 & #764 - androguard sign asn1crypto(...).fingerprint removed

### DIFF
--- a/androguard/cli/main.py
+++ b/androguard/cli/main.py
@@ -10,6 +10,7 @@ from loguru import logger
 from pygments import highlight
 from pygments.lexers import get_lexer_by_name
 from pygments.formatters.terminal import TerminalFormatter
+from oscrypto import asymmetric
 
 # internal modules
 from androguard.core import androconf
@@ -360,14 +361,14 @@ def androsign_main(args_apk, args_hash, args_all, show):
 
             for public_key in pkeys:
                 if show:
-                    x509_public_key = keys.PublicKeyInfo.load(public_key)
+                    x509_public_key = asymmetric.load_public_key(public_key)
                     print("PublicKey Algorithm:", x509_public_key.algorithm)
                     print("Bit Size:", x509_public_key.bit_size)
                     print("Fingerprint:", binascii.hexlify(x509_public_key.fingerprint))
                     try:
-                        print("Hash Algorithm:", x509_public_key.hash_algo)
+                        print("Hash Algorithm:", x509_public_key.asn1.hash_algo)
                     except ValueError as ve:
-                        # RSA pkey does not have an hash algorithm
+                        # RSA pkey does not have a hash algorithm
                         pass
                 print()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ matplotlib
 networkx
 PyQt5
 pyyaml
+oscrypto>=1.3.0


### PR DESCRIPTION
This commit replaces the outdated:
`asn1crypto.keys.PublicKeyInfo().fingerprint` call

With the new:
`oscrypto.asymmetric.PublicKey().fingerprint` call

ValueError/ve is properly excepted and when printed, it shows "Only DSA keys are generated using a hash algorithm, this key is RSA" for RSA signed apk's.

This commit satisfies the:
`asn1crypto._errors.APIException: asn1crypto.keys.PublicKeyInfo().fingerprint has been removed, please use oscrypto.asymmetric.PublicKey().fingerprint instead` while still keeping the original behavior.