### PR TITLE
Convert `androguard.decompiler.dast` functions into instance or static methods

### DIFF
--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -184,10 +184,6 @@ def literal_float(f):
     return literal(str(f) + 'f', ('.float', 0))
 
 
-def literal_double(f):
-    return literal(str(f), ('.double', 0))
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -603,7 +599,7 @@ class JSONWriter:
             elif op.type in 'F':
                 return literal_float(op.cst)
             elif op.type in 'D':
-                return literal_double(op.cst)
+                return self.literal_double(op.cst)
             elif op.type == 'Ljava/lang/Class;':
                 return literal_class(op.clsdesc)
             return dummy('??? Unexpected constant: ' + str(op.type))
@@ -707,3 +703,7 @@ class JSONWriter:
     @staticmethod
     def literal_null():
         return literal('null', ('.null', 0))
+
+    @staticmethod
+    def literal_double(f):
+        return literal(str(f), ('.double', 0))

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -80,10 +80,6 @@ def unary_postfix(left, op):
     return ['Unary', [left], op, True]
 
 
-def var_decl(typen, var):
-    return [typen, var]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -143,7 +139,7 @@ class JSONWriter:
         for ptype, name in zip(m.params_type, params):
             t = self.parse_descriptor(ptype)
             v = local('p{}'.format(name))
-            paramdecls.append(var_decl(t, v))
+            paramdecls.append(self.var_decl(t, v))
 
         if self.graph is None:
             body = None
@@ -365,7 +361,7 @@ class JSONWriter:
             else:
                 ctype = catch_node.catch_type
                 name = '_'
-            catch_decl = var_decl(self.parse_descriptor(ctype), local(name))
+            catch_decl = self.var_decl(self.parse_descriptor(ctype), local(name))
 
             with self as body:
                 self.visit_node(catch_node.catch_start)
@@ -598,7 +594,7 @@ class JSONWriter:
     def visit_decl(self, var, init_expr=None):
         t = self.parse_descriptor(var.get_type())
         v = local('v{}'.format(var.name))
-        return self.local_decl_stmt(init_expr, var_decl(t, v))
+        return self.local_decl_stmt(init_expr, self.var_decl(t, v))
 
     @staticmethod
     def literal_null():
@@ -703,3 +699,7 @@ class JSONWriter:
     @staticmethod
     def dummy(*args):
         return ['Dummy', args]
+
+    @staticmethod
+    def var_decl(typen, var):
+        return [typen, var]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -160,10 +160,6 @@ def literal_string(s):
     return literal(str(s), ('java/lang/String', 0))
 
 
-def literal_class(desc):
-    return literal(parse_descriptor(desc), ('java/lang/Class', 0))
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -581,7 +577,7 @@ class JSONWriter:
             elif op.type in 'D':
                 return self.literal_double(op.cst)
             elif op.type == 'Ljava/lang/Class;':
-                return literal_class(op.clsdesc)
+                return self.literal_class(op.clsdesc)
             return dummy('??? Unexpected constant: ' + str(op.type))
 
         if isinstance(op, instruction.FillArrayExpression):
@@ -707,3 +703,7 @@ class JSONWriter:
     @staticmethod
     def literal_bool(b):
         return literal(str(b).lower(), ('.boolean', 0))
+
+    @staticmethod
+    def literal_class(desc):
+        return literal(parse_descriptor(desc), ('java/lang/Class', 0))

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -168,10 +168,6 @@ def literal_bool(b):
     return literal(str(b).lower(), ('.boolean', 0))
 
 
-def literal_int(b):
-    return literal(str(b), ('.int', 0))
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -570,7 +566,7 @@ class JSONWriter:
                 if op.op == opcode_ins.Op.EQUAL:
                     expr = unary_prefix('!', expr)
             elif atype in 'VBSCIJFD':
-                expr = binary_infix(op.op, expr, literal_int(0))
+                expr = binary_infix(op.op, expr, self.literal_int(0))
             else:
                 expr = binary_infix(op.op, expr, self.literal_null())
             return expr
@@ -581,7 +577,7 @@ class JSONWriter:
             elif op.type == 'Z':
                 return literal_bool(op.cst == 0)
             elif op.type in 'ISCB':
-                return literal_int(op.cst2)
+                return self.literal_int(op.cst2)
             elif op.type in 'J':
                 return self.literal_long(op.cst2)
             elif op.type in 'F':
@@ -681,7 +677,7 @@ class JSONWriter:
         else:  # FIXME: other cases
             for i in range(value.size):
                 tab.append(data[i])
-        return array_initializer(list(map(literal_int, tab)))
+        return array_initializer(list(map(self.literal_int, tab)))
 
     def visit_decl(self, var, init_expr=None):
         t = parse_descriptor(var.get_type())
@@ -707,3 +703,7 @@ class JSONWriter:
     @staticmethod
     def literal_hex_int(b):
         return literal(hex(b), ('.int', 0))
+
+    @staticmethod
+    def literal_int(b):
+        return literal(str(b), ('.int', 0))

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -107,10 +107,6 @@ def throw_stmt(expr):
     return ['ThrowStatement', expr]
 
 
-def jump_stmt(keyword):
-    return ['JumpStatement', keyword, None]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -277,7 +273,7 @@ class JSONWriter:
         if self.loop_follow[-1] in (cond.true, cond.false):
             cond_expr = self.get_cond(cond)
             with self as scope:
-                self.add(jump_stmt('break'))
+                self.add(self.jump_stmt('break'))
             scopes.append(scope)
 
             with self as scope:
@@ -348,7 +344,7 @@ class JSONWriter:
             with self as body:
                 self.visit_node(node)
                 if self.need_break:
-                    self.add(jump_stmt('break'))
+                    self.add(self.jump_stmt('break'))
                 else:
                     self.need_break = True
             ksv_pairs.append((cur_ks, body))
@@ -368,7 +364,7 @@ class JSONWriter:
             self.visit_ins(ins)
         if len(sucs) == 1:
             if sucs[0] is self.loop_follow[-1]:
-                self.add(jump_stmt('break'))
+                self.add(self.jump_stmt('break'))
             elif sucs[0] is self.next_case:
                 self.need_break = False
             else:
@@ -706,3 +702,7 @@ class JSONWriter:
     def loop_stmt(isdo, cond_expr, body):
         type_ = 'DoStatement' if isdo else 'WhileStatement'
         return [type_, None, cond_expr, body]
+
+    @staticmethod
+    def jump_stmt(keyword):
+        return ['JumpStatement', keyword, None]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -188,10 +188,6 @@ def literal_double(f):
     return literal(str(f), ('.double', 0))
 
 
-def literal_null():
-    return literal('null', ('.null', 0))
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -592,7 +588,7 @@ class JSONWriter:
             elif atype in 'VBSCIJFD':
                 expr = binary_infix(op.op, expr, literal_int(0))
             else:
-                expr = binary_infix(op.op, expr, literal_null())
+                expr = binary_infix(op.op, expr, self.literal_null())
             return expr
 
         if isinstance(op, instruction.Constant):
@@ -707,3 +703,7 @@ class JSONWriter:
         t = parse_descriptor(var.get_type())
         v = local('v{}'.format(var.name))
         return local_decl_stmt(init_expr, var_decl(t, v))
+
+    @staticmethod
+    def literal_null():
+        return literal('null', ('.null', 0))

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -95,10 +95,6 @@ def expression_stmt(expr):
     return ['ExpressionStatement', expr]
 
 
-def local_decl_stmt(expr, decl):
-    return ['LocalDeclarationStatement', expr, decl]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -613,7 +609,7 @@ class JSONWriter:
     def visit_decl(self, var, init_expr=None):
         t = self.parse_descriptor(var.get_type())
         v = local('v{}'.format(var.name))
-        return local_decl_stmt(init_expr, var_decl(t, v))
+        return self.local_decl_stmt(init_expr, var_decl(t, v))
 
     @staticmethod
     def literal_null():
@@ -706,3 +702,7 @@ class JSONWriter:
     @staticmethod
     def return_stmt(expr):
         return ['ReturnStatement', expr]
+
+    @staticmethod
+    def local_decl_stmt(expr, decl):
+        return ['LocalDeclarationStatement', expr, decl]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -134,13 +134,6 @@ def statement_block():
     return ['BlockStatement', None, []]
 
 
-# Add a statement to the end of a statement block
-def _append(sb, stmt):
-    assert (sb[0] == 'BlockStatement')
-    if stmt is not None:
-        sb[2].append(stmt)
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -173,7 +166,7 @@ class JSONWriter:
 
     # Add a statement to the current context
     def add(self, val):
-        _append(self.context[-1], val)
+        self._append(self.context[-1], val)
 
     def visit_ins(self, op):
         self.add(self._visit_ins(op, isCtor=self.constructor))
@@ -706,3 +699,10 @@ class JSONWriter:
             return typen(desc[1:-1], dim)
         # invalid descriptor (probably None)
         return dummy(str(desc))
+
+    @staticmethod
+    def _append(sb, stmt):
+        # Add a statement to the end of a statement block
+        assert (sb[0] == 'BlockStatement')
+        if stmt is not None:
+            sb[2].append(stmt)

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -198,19 +198,6 @@ def visit_decl(var, init_expr=None):
     return local_decl_stmt(init_expr, var_decl(t, v))
 
 
-def visit_arr_data(value):
-    data = value.get_data()
-    tab = []
-    elem_size = value.element_width
-    if elem_size == 4:
-        for i in range(0, value.size * 4, 4):
-            tab.append(struct.unpack('<i', data[i:i + 4])[0])
-    else:  # FIXME: other cases
-        for i in range(value.size):
-            tab.append(data[i])
-    return array_initializer(list(map(literal_int, tab)))
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -633,7 +620,7 @@ class JSONWriter:
 
         if isinstance(op, instruction.FillArrayExpression):
             array_expr = self.visit_expr(op.var_map[op.reg])
-            rhs = visit_arr_data(op.value)
+            rhs = self.visit_arr_data(op.value)
             return assignment(array_expr, rhs)
         if isinstance(op, instruction.FilledArrayExpression):
             tn = parse_descriptor(op.type)
@@ -709,3 +696,15 @@ class JSONWriter:
             # assert(op.declared)
             return local('v{}'.format(op.name))
         return dummy('??? Unexpected op: ' + type(op).__name__)
+
+    def visit_arr_data(self, value):
+        data = value.get_data()
+        tab = []
+        elem_size = value.element_width
+        if elem_size == 4:
+            for i in range(0, value.size * 4, 4):
+                tab.append(struct.unpack('<i', data[i:i + 4])[0])
+        else:  # FIXME: other cases
+            for i in range(value.size):
+                tab.append(data[i])
+        return array_initializer(list(map(literal_int, tab)))

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -180,10 +180,6 @@ def literal_long(b):
     return literal(str(b) + 'L', ('.long', 0))
 
 
-def literal_float(f):
-    return literal(str(f) + 'f', ('.float', 0))
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -597,7 +593,7 @@ class JSONWriter:
             elif op.type in 'J':
                 return literal_long(op.cst2)
             elif op.type in 'F':
-                return literal_float(op.cst)
+                return self.literal_float(op.cst)
             elif op.type in 'D':
                 return self.literal_double(op.cst)
             elif op.type == 'Ljava/lang/Class;':
@@ -707,3 +703,7 @@ class JSONWriter:
     @staticmethod
     def literal_double(f):
         return literal(str(f), ('.double', 0))
+
+    @staticmethod
+    def literal_float(f):
+        return literal(str(f) + 'f', ('.float', 0))

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -76,10 +76,6 @@ def unary_prefix(op, left):
     return ['Unary', [left], op, False]
 
 
-def unary_postfix(left, op):
-    return ['Unary', [left], op, True]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -420,7 +416,7 @@ class JSONWriter:
             # post increment/decrement
             if rhs.op in '+-' and isinstance(exp_rhs,
                                              instruction.Constant) and exp_rhs.get_int_value() == 1:
-                return unary_postfix(self.visit_expr(lhs), rhs.op * 2)
+                return self.unary_postfix(self.visit_expr(lhs), rhs.op * 2)
             # compound assignment
             return assignment(self.visit_expr(lhs), self.visit_expr(exp_rhs), op=rhs.op)
         return assignment(self.visit_expr(lhs), self.visit_expr(rhs))
@@ -703,3 +699,7 @@ class JSONWriter:
     @staticmethod
     def var_decl(typen, var):
         return [typen, var]
+
+    @staticmethod
+    def unary_postfix(left, op):
+        return ['Unary', [left], op, True]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -164,10 +164,6 @@ def literal_class(desc):
     return literal(parse_descriptor(desc), ('java/lang/Class', 0))
 
 
-def literal_bool(b):
-    return literal(str(b).lower(), ('.boolean', 0))
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -294,7 +290,7 @@ class JSONWriter:
 
         elif loop.looptype.is_endless:
             isDo = False
-            cond_expr = literal_bool(True)
+            cond_expr = self.literal_bool(True)
 
         with self as body:
             self.loop_follow.append(follow)
@@ -575,7 +571,7 @@ class JSONWriter:
             if op.type == 'Ljava/lang/String;':
                 return literal_string(op.cst)
             elif op.type == 'Z':
-                return literal_bool(op.cst == 0)
+                return self.literal_bool(op.cst == 0)
             elif op.type in 'ISCB':
                 return self.literal_int(op.cst2)
             elif op.type in 'J':
@@ -707,3 +703,7 @@ class JSONWriter:
     @staticmethod
     def literal_int(b):
         return literal(str(b), ('.int', 0))
+
+    @staticmethod
+    def literal_bool(b):
+        return literal(str(b).lower(), ('.boolean', 0))

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -155,11 +155,6 @@ def parse_descriptor(desc: str) -> list:
     return dummy(str(desc))
 
 
-# Note: the literal_foo functions (and dummy) are also imported by decompile.py
-def literal_string(s):
-    return literal(str(s), ('java/lang/String', 0))
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -565,7 +560,7 @@ class JSONWriter:
 
         if isinstance(op, instruction.Constant):
             if op.type == 'Ljava/lang/String;':
-                return literal_string(op.cst)
+                return self.literal_string(op.cst)
             elif op.type == 'Z':
                 return self.literal_bool(op.cst == 0)
             elif op.type in 'ISCB':
@@ -707,3 +702,7 @@ class JSONWriter:
     @staticmethod
     def literal_class(desc):
         return literal(parse_descriptor(desc), ('java/lang/Class', 0))
+
+    @staticmethod
+    def literal_string(s):
+        return literal(str(s), ('java/lang/String', 0))

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -46,10 +46,6 @@ def cast(tn, arg):
     return ['Cast', [tn, arg]]
 
 
-def field_access(triple, left):
-    return ['FieldAccess', [left], triple]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -398,7 +394,7 @@ class JSONWriter:
     def visit_expr(self, op):
         if isinstance(op, instruction.ArrayLengthExpression):
             expr = self.visit_expr(op.var_map[op.array])
-            return field_access([None, 'length', None], expr)
+            return self.field_access([None, 'length', None], expr)
         if isinstance(op, instruction.ArrayLoadExpression):
             array_expr = self.visit_expr(op.var_map[op.array])
             index_expr = self.visit_expr(op.var_map[op.idx])
@@ -481,10 +477,10 @@ class JSONWriter:
         if isinstance(op, instruction.InstanceExpression):
             triple = op.clsdesc[1:-1], op.name, op.ftype
             expr = self.visit_expr(op.var_map[op.arg])
-            return field_access(triple, expr)
+            return self.field_access(triple, expr)
         if isinstance(op, instruction.InstanceInstruction):
             triple = op.clsdesc[1:-1], op.name, op.atype
-            lhs = field_access(triple, self.visit_expr(op.var_map[op.lhs]))
+            lhs = self.field_access(triple, self.visit_expr(op.var_map[op.lhs]))
             rhs = self.visit_expr(op.var_map[op.rhs])
             return assignment(lhs, rhs)
 
@@ -529,10 +525,10 @@ class JSONWriter:
             return self.local('p{}'.format(op.v))
         if isinstance(op, instruction.StaticExpression):
             triple = op.clsdesc[1:-1], op.name, op.ftype
-            return field_access(triple, self.parse_descriptor(op.clsdesc))
+            return self.field_access(triple, self.parse_descriptor(op.clsdesc))
         if isinstance(op, instruction.StaticInstruction):
             triple = op.clsdesc[1:-1], op.name, op.ftype
-            lhs = field_access(triple, self.parse_descriptor(op.clsdesc))
+            lhs = self.field_access(triple, self.parse_descriptor(op.clsdesc))
             rhs = self.visit_expr(op.var_map[op.rhs])
             return assignment(lhs, rhs)
         if isinstance(op, instruction.SwitchExpression):
@@ -703,3 +699,7 @@ class JSONWriter:
     @staticmethod
     def literal(result, tt):
         return ['Literal', result, tt]
+
+    @staticmethod
+    def field_access(triple, left):
+        return ['FieldAccess', [left], triple]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -192,12 +192,6 @@ def literal_null():
     return literal('null', ('.null', 0))
 
 
-def visit_decl(var, init_expr=None):
-    t = parse_descriptor(var.get_type())
-    v = local('v{}'.format(var.name))
-    return local_decl_stmt(init_expr, var_decl(t, v))
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -303,7 +297,7 @@ class JSONWriter:
         self.visited_nodes.add(node)
         for var in node.var_to_declare:
             if not var.declared:
-                self.add(visit_decl(var))
+                self.add(self.visit_decl(var))
             var.declared = True
         node.visit(self)
 
@@ -515,7 +509,7 @@ class JSONWriter:
             if isinstance(lhs, instruction.Variable) and not lhs.declared:
                 lhs.declared = True
                 expr = self.visit_expr(rhs)
-                return visit_decl(lhs, expr)
+                return self.visit_decl(lhs, expr)
 
         # skip this() at top of constructors
         if isCtor and isinstance(op, instruction.AssignExpression):
@@ -708,3 +702,8 @@ class JSONWriter:
             for i in range(value.size):
                 tab.append(data[i])
         return array_initializer(list(map(literal_int, tab)))
+
+    def visit_decl(self, var, init_expr=None):
+        t = parse_descriptor(var.get_type())
+        v = local('v{}'.format(var.name))
+        return local_decl_stmt(init_expr, var_decl(t, v))

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -103,10 +103,6 @@ def return_stmt(expr):
     return ['ReturnStatement', expr]
 
 
-def throw_stmt(expr):
-    return ['ThrowStatement', expr]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -411,7 +407,7 @@ class JSONWriter:
             expr = None if op.arg is None else self.visit_expr(op.var_map[op.arg])
             return return_stmt(expr)
         elif isinstance(op, instruction.ThrowExpression):
-            return throw_stmt(self.visit_expr(op.var_map[op.ref]))
+            return self.throw_stmt(self.visit_expr(op.var_map[op.ref]))
         elif isinstance(op, instruction.NopExpression):
             return None
 
@@ -706,3 +702,7 @@ class JSONWriter:
     @staticmethod
     def jump_stmt(keyword):
         return ['JumpStatement', keyword, None]
+
+    @staticmethod
+    def throw_stmt(expr):
+        return ['ThrowStatement', expr]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -120,10 +120,6 @@ def try_stmt(tryb, pairs):
     return ['TryStatement', None, tryb, pairs]
 
 
-def if_stmt(cond_expr, scopes):
-    return ['IfStatement', None, cond_expr, scopes]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -297,7 +293,7 @@ class JSONWriter:
                 self.visit_node(cond.false)
             scopes.append(scope)
 
-            self.add(if_stmt(cond_expr, scopes))
+            self.add(self.if_stmt(cond_expr, scopes))
         elif follow is not None:
             if cond.true in (follow, self.next_case) or \
                             cond.num > cond.true.num:
@@ -318,7 +314,7 @@ class JSONWriter:
                 scopes.append(scope)
             self.if_follow.pop()
 
-            self.add(if_stmt(cond_expr, scopes))
+            self.add(self.if_stmt(cond_expr, scopes))
             self.visit_node(follow)
         else:
             cond_expr = self.get_cond(cond)
@@ -329,7 +325,7 @@ class JSONWriter:
             with self as scope:
                 self.visit_node(cond.false)
             scopes.append(scope)
-            self.add(if_stmt(cond_expr, scopes))
+            self.add(self.if_stmt(cond_expr, scopes))
 
     def visit_switch_node(self, switch):
         lins = switch.get_ins()
@@ -706,3 +702,7 @@ class JSONWriter:
     @staticmethod
     def switch_stmt(cond_expr, ksv_pairs):
         return ['SwitchStatement', None, cond_expr, ksv_pairs]
+
+    @staticmethod
+    def if_stmt(cond_expr, scopes):
+        return ['IfStatement', None, cond_expr, scopes]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -172,10 +172,6 @@ def literal_int(b):
     return literal(str(b), ('.int', 0))
 
 
-def literal_hex_int(b):
-    return literal(hex(b), ('.int', 0))
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -707,3 +703,7 @@ class JSONWriter:
     @staticmethod
     def literal_long(b):
         return literal(str(b) + 'L', ('.long', 0))
+
+    @staticmethod
+    def literal_hex_int(b):
+        return literal(hex(b), ('.int', 0))

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -30,10 +30,6 @@ def array_creation(tn, params, dim):
     return ['ArrayCreation', [tn] + params, dim]
 
 
-def array_initializer(params, tn=None):
-    return ['ArrayInitializer', params, tn]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -462,7 +458,7 @@ class JSONWriter:
         if isinstance(op, instruction.FilledArrayExpression):
             tn = self.parse_descriptor(op.type)
             params = [self.visit_expr(op.var_map[x]) for x in op.args]
-            return array_initializer(params, tn)
+            return self.array_initializer(params, tn)
         if isinstance(op, instruction.InstanceExpression):
             triple = op.clsdesc[1:-1], op.name, op.ftype
             expr = self.visit_expr(op.var_map[op.arg])
@@ -544,7 +540,7 @@ class JSONWriter:
         else:  # FIXME: other cases
             for i in range(value.size):
                 tab.append(data[i])
-        return array_initializer(list(map(self.literal_int, tab)))
+        return self.array_initializer(list(map(self.literal_int, tab)))
 
     def visit_decl(self, var, init_expr=None):
         t = self.parse_descriptor(var.get_type())
@@ -704,3 +700,7 @@ class JSONWriter:
     @staticmethod
     def assignment(lhs, rhs, op=''):
         return ['Assignment', [lhs, rhs], op]
+
+    @staticmethod
+    def array_initializer(params, tn=None):
+        return ['ArrayInitializer', params, tn]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -68,10 +68,6 @@ def parenthesis(expr):
     return ['Parenthesis', [expr]]
 
 
-def typen(baset: str, dim: int) -> list:
-    return ['TypeName', (baset, dim)]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -632,9 +628,9 @@ class JSONWriter:
             dim += 1
 
         if desc in TYPE_DESCRIPTOR:
-            return typen('.' + TYPE_DESCRIPTOR[desc], dim)
+            return JSONWriter.typen('.' + TYPE_DESCRIPTOR[desc], dim)
         if desc and desc[0] == 'L' and desc[-1] == ';':
-            return typen(desc[1:-1], dim)
+            return JSONWriter.typen(desc[1:-1], dim)
         # invalid descriptor (probably None)
         return JSONWriter.dummy(str(desc))
 
@@ -703,3 +699,7 @@ class JSONWriter:
     @staticmethod
     def unary_prefix(op, left):
         return ['Unary', [left], op, False]
+
+    @staticmethod
+    def typen(baset: str, dim: int) -> list:
+        return ['TypeName', (baset, dim)]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -88,13 +88,6 @@ def dummy(*args):
     return ['Dummy', args]
 
 
-################################################################################
-
-
-def expression_stmt(expr):
-    return ['ExpressionStatement', expr]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -250,7 +243,7 @@ class JSONWriter:
 
         follow = cond.follow['if']
         if cond.false is cond.true:
-            self.add(expression_stmt(self.get_cond(cond)))
+            self.add(self.expression_stmt(self.get_cond(cond)))
             self.visit_node(cond.true)
             return
 
@@ -427,7 +420,7 @@ class JSONWriter:
             if op.var_map.get(op.lhs) is op.var_map.get(op.rhs):
                 return None
 
-        return expression_stmt(self.visit_expr(op))
+        return self.expression_stmt(self.visit_expr(op))
 
     def write_inplace_if_possible(self, lhs, rhs):
         if isinstance(rhs, instruction.BinaryExpression) and lhs == rhs.var_map[rhs.arg1]:
@@ -706,3 +699,7 @@ class JSONWriter:
     @staticmethod
     def local_decl_stmt(expr, decl):
         return ['LocalDeclarationStatement', expr, decl]
+
+    @staticmethod
+    def expression_stmt(expr):
+        return ['ExpressionStatement', expr]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -58,12 +58,6 @@ def local(name):
     return ['Local', name]
 
 
-def method_invocation(triple, name, base, params):
-    if base is None:
-        return ['MethodInvocation', params, triple, name, False]
-    return ['MethodInvocation', [base] + params, triple, name, True]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -509,14 +503,14 @@ class JSONWriter:
             if op.name == '<init>':
                 if isinstance(base, instruction.ThisParam):
                     keyword = 'this' if base.type[1:-1] == op.triple[0] else 'super'
-                    return method_invocation(op.triple, keyword, None, params)
+                    return self.method_invocation(op.triple, keyword, None, params)
                 elif isinstance(base, instruction.NewInstance):
                     return ['ClassInstanceCreation', op.triple, params,
                             self.parse_descriptor(base.type)]
                 else:
                     assert (isinstance(base, instruction.Variable))
                     # fallthrough to create dummy <init> call
-            return method_invocation(op.triple, op.name, self.visit_expr(base), params)
+            return self.method_invocation(op.triple, op.name, self.visit_expr(base), params)
         # for unmatched monitor instructions, just create dummy expressions
         if isinstance(op, instruction.MonitorEnterExpression):
             return self.dummy("monitor enter(", self.visit_expr(op.var_map[op.ref]), ")")
@@ -703,3 +697,9 @@ class JSONWriter:
     @staticmethod
     def parenthesis(expr):
         return ['Parenthesis', [expr]]
+
+    @staticmethod
+    def method_invocation(triple, name, base, params):
+        if base is None:
+            return ['MethodInvocation', params, triple, name, False]
+        return ['MethodInvocation', [base] + params, triple, name, True]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -176,10 +176,6 @@ def literal_hex_int(b):
     return literal(hex(b), ('.int', 0))
 
 
-def literal_long(b):
-    return literal(str(b) + 'L', ('.long', 0))
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -591,7 +587,7 @@ class JSONWriter:
             elif op.type in 'ISCB':
                 return literal_int(op.cst2)
             elif op.type in 'J':
-                return literal_long(op.cst2)
+                return self.literal_long(op.cst2)
             elif op.type in 'F':
                 return self.literal_float(op.cst)
             elif op.type in 'D':
@@ -707,3 +703,7 @@ class JSONWriter:
     @staticmethod
     def literal_float(f):
         return literal(str(f) + 'f', ('.float', 0))
+
+    @staticmethod
+    def literal_long(b):
+        return literal(str(b) + 'L', ('.long', 0))

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -42,10 +42,6 @@ def binary_infix(op, left, right):
     return ['BinaryInfix', [left, right], op]
 
 
-def cast(tn, arg):
-    return ['Cast', [tn, arg]]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -427,7 +423,8 @@ class JSONWriter:
 
         if isinstance(op, instruction.CheckCastExpression):
             lhs = op.var_map.get(op.arg)
-            return self.parenthesis(cast(self.parse_descriptor(op.clsdesc), self.visit_expr(lhs)))
+            return self.parenthesis(self.cast(self.parse_descriptor(op.clsdesc),
+                                              self.visit_expr(lhs)))
         if isinstance(op, instruction.ConditionalExpression):
             lhs = op.var_map.get(op.arg1)
             rhs = op.var_map.get(op.arg2)
@@ -536,7 +533,7 @@ class JSONWriter:
         if isinstance(op, instruction.UnaryExpression):
             lhs = op.var_map.get(op.arg)
             if isinstance(op, instruction.CastExpression):
-                expr = cast(self.parse_descriptor(op.clsdesc), self.visit_expr(lhs))
+                expr = self.cast(self.parse_descriptor(op.clsdesc), self.visit_expr(lhs))
             else:
                 expr = self.unary_prefix(op.op, self.visit_expr(lhs))
             return self.parenthesis(expr)
@@ -703,3 +700,7 @@ class JSONWriter:
     @staticmethod
     def field_access(triple, left):
         return ['FieldAccess', [left], triple]
+
+    @staticmethod
+    def cast(tn, arg):
+        return ['Cast', [tn, arg]]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -26,10 +26,6 @@ def array_access(arr, ind) -> list:
     return ['ArrayAccess', [arr, ind]]
 
 
-def array_creation(tn, params, dim):
-    return ['ArrayCreation', [tn] + params, dim]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -500,7 +496,7 @@ class JSONWriter:
         if isinstance(op, instruction.NewArrayExpression):
             tn = self.parse_descriptor(op.type[1:])
             expr = self.visit_expr(op.var_map[op.size])
-            return array_creation(tn, [expr], 1)
+            return self.array_creation(tn, [expr], 1)
         # create dummy expression for unmatched newinstance
         if isinstance(op, instruction.NewInstance):
             return self.dummy("new ", self.parse_descriptor(op.type))
@@ -704,3 +700,7 @@ class JSONWriter:
     @staticmethod
     def array_initializer(params, tn=None):
         return ['ArrayInitializer', params, tn]
+
+    @staticmethod
+    def array_creation(tn, params, dim):
+        return ['ArrayCreation', [tn] + params, dim]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -22,10 +22,6 @@ from androguard.core.dex.dex_types import TYPE_DESCRIPTOR
 from loguru import logger
 
 
-def array_access(arr, ind) -> list:
-    return ['ArrayAccess', [arr, ind]]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -378,12 +374,12 @@ class JSONWriter:
         if isinstance(op, instruction.ArrayLoadExpression):
             array_expr = self.visit_expr(op.var_map[op.array])
             index_expr = self.visit_expr(op.var_map[op.idx])
-            return array_access(array_expr, index_expr)
+            return self.array_access(array_expr, index_expr)
         if isinstance(op, instruction.ArrayStoreInstruction):
             array_expr = self.visit_expr(op.var_map[op.array])
             index_expr = self.visit_expr(op.var_map[op.index])
             rhs = self.visit_expr(op.var_map[op.rhs])
-            return self.assignment(array_access(array_expr, index_expr), rhs)
+            return self.assignment(self.array_access(array_expr, index_expr), rhs)
 
         if isinstance(op, instruction.AssignExpression):
             lhs = op.var_map.get(op.lhs)
@@ -704,3 +700,7 @@ class JSONWriter:
     @staticmethod
     def array_creation(tn, params, dim):
         return ['ArrayCreation', [tn] + params, dim]
+
+    @staticmethod
+    def array_access(arr, ind) -> list:
+        return ['ArrayAccess', [arr, ind]]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -72,10 +72,6 @@ def typen(baset: str, dim: int) -> list:
     return ['TypeName', (baset, dim)]
 
 
-def unary_prefix(op, left):
-    return ['Unary', [left], op, False]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -472,7 +468,7 @@ class JSONWriter:
             atype = str(arg.get_type())
             if atype == 'Z':
                 if op.op == opcode_ins.Op.EQUAL:
-                    expr = unary_prefix('!', expr)
+                    expr = self.unary_prefix('!', expr)
             elif atype in 'VBSCIJFD':
                 expr = binary_infix(op.op, expr, self.literal_int(0))
             else:
@@ -568,7 +564,7 @@ class JSONWriter:
             if isinstance(op, instruction.CastExpression):
                 expr = cast(self.parse_descriptor(op.clsdesc), self.visit_expr(lhs))
             else:
-                expr = unary_prefix(op.op, self.visit_expr(lhs))
+                expr = self.unary_prefix(op.op, self.visit_expr(lhs))
             return parenthesis(expr)
         if isinstance(op, instruction.Variable):
             # assert(op.declared)
@@ -703,3 +699,7 @@ class JSONWriter:
     @staticmethod
     def unary_postfix(left, op):
         return ['Unary', [left], op, True]
+
+    @staticmethod
+    def unary_prefix(op, left):
+        return ['Unary', [left], op, False]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -64,10 +64,6 @@ def method_invocation(triple, name, base, params):
     return ['MethodInvocation', [base] + params, triple, name, True]
 
 
-def parenthesis(expr):
-    return ['Parenthesis', [expr]]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -147,8 +143,8 @@ class JSONWriter:
     def _visit_condition(self, cond):
         if cond.isnot:
             cond.cond1.neg()
-        left = parenthesis(self.get_cond(cond.cond1))
-        right = parenthesis(self.get_cond(cond.cond2))
+        left = self.parenthesis(self.get_cond(cond.cond1))
+        right = self.parenthesis(self.get_cond(cond.cond2))
         op = '&&' if cond.isand else '||'
         res = binary_infix(op, left, right)
         return res
@@ -444,12 +440,12 @@ class JSONWriter:
             rhs = op.var_map.get(op.arg2)
             expr = binary_infix(op.op, self.visit_expr(lhs), self.visit_expr(rhs))
             if not isinstance(op, instruction.BinaryCompExpression):
-                expr = parenthesis(expr)
+                expr = self.parenthesis(expr)
             return expr
 
         if isinstance(op, instruction.CheckCastExpression):
             lhs = op.var_map.get(op.arg)
-            return parenthesis(cast(self.parse_descriptor(op.clsdesc), self.visit_expr(lhs)))
+            return self.parenthesis(cast(self.parse_descriptor(op.clsdesc), self.visit_expr(lhs)))
         if isinstance(op, instruction.ConditionalExpression):
             lhs = op.var_map.get(op.arg1)
             rhs = op.var_map.get(op.arg2)
@@ -561,7 +557,7 @@ class JSONWriter:
                 expr = cast(self.parse_descriptor(op.clsdesc), self.visit_expr(lhs))
             else:
                 expr = self.unary_prefix(op.op, self.visit_expr(lhs))
-            return parenthesis(expr)
+            return self.parenthesis(expr)
         if isinstance(op, instruction.Variable):
             # assert(op.declared)
             return local('v{}'.format(op.name))
@@ -703,3 +699,7 @@ class JSONWriter:
     @staticmethod
     def typen(baset: str, dim: int) -> list:
         return ['TypeName', (baset, dim)]
+
+    @staticmethod
+    def parenthesis(expr):
+        return ['Parenthesis', [expr]]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -124,10 +124,6 @@ def if_stmt(cond_expr, scopes):
     return ['IfStatement', None, cond_expr, scopes]
 
 
-def switch_stmt(cond_expr, ksv_pairs):
-    return ['SwitchStatement', None, cond_expr, ksv_pairs]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -375,7 +371,7 @@ class JSONWriter:
                 self.visit_node(default)
             ksv_pairs.append(([None], body))
 
-        self.add(switch_stmt(cond_expr, ksv_pairs))
+        self.add(self.switch_stmt(cond_expr, ksv_pairs))
         self.switch_follow.pop()
         self.visit_node(follow)
 
@@ -706,3 +702,7 @@ class JSONWriter:
         # Create empty statement block (statements to be appended later)
         # Note, the code below assumes this can be modified in place
         return ['BlockStatement', None, []]
+
+    @staticmethod
+    def switch_stmt(cond_expr, ksv_pairs):
+        return ['SwitchStatement', None, cond_expr, ksv_pairs]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -38,10 +38,6 @@ def assignment(lhs, rhs, op=''):
     return ['Assignment', [lhs, rhs], op]
 
 
-def binary_infix(op, left, right):
-    return ['BinaryInfix', [left, right], op]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -124,7 +120,7 @@ class JSONWriter:
         left = self.parenthesis(self.get_cond(cond.cond1))
         right = self.parenthesis(self.get_cond(cond.cond2))
         op = '&&' if cond.isand else '||'
-        res = binary_infix(op, left, right)
+        res = self.binary_infix(op, left, right)
         return res
 
     def get_cond(self, node):
@@ -416,7 +412,7 @@ class JSONWriter:
         if isinstance(op, instruction.BinaryExpression):
             lhs = op.var_map.get(op.arg1)
             rhs = op.var_map.get(op.arg2)
-            expr = binary_infix(op.op, self.visit_expr(lhs), self.visit_expr(rhs))
+            expr = self.binary_infix(op.op, self.visit_expr(lhs), self.visit_expr(rhs))
             if not isinstance(op, instruction.BinaryCompExpression):
                 expr = self.parenthesis(expr)
             return expr
@@ -428,7 +424,7 @@ class JSONWriter:
         if isinstance(op, instruction.ConditionalExpression):
             lhs = op.var_map.get(op.arg1)
             rhs = op.var_map.get(op.arg2)
-            return binary_infix(op.op, self.visit_expr(lhs), self.visit_expr(rhs))
+            return self.binary_infix(op.op, self.visit_expr(lhs), self.visit_expr(rhs))
         if isinstance(op, instruction.ConditionalZExpression):
             arg = op.var_map[op.arg]
             if isinstance(arg, instruction.BinaryCompExpression):
@@ -441,9 +437,9 @@ class JSONWriter:
                 if op.op == opcode_ins.Op.EQUAL:
                     expr = self.unary_prefix('!', expr)
             elif atype in 'VBSCIJFD':
-                expr = binary_infix(op.op, expr, self.literal_int(0))
+                expr = self.binary_infix(op.op, expr, self.literal_int(0))
             else:
-                expr = binary_infix(op.op, expr, self.literal_null())
+                expr = self.binary_infix(op.op, expr, self.literal_null())
             return expr
 
         if isinstance(op, instruction.Constant):
@@ -704,3 +700,7 @@ class JSONWriter:
     @staticmethod
     def cast(tn, arg):
         return ['Cast', [tn, arg]]
+
+    @staticmethod
+    def binary_infix(op, left, right):
+        return ['BinaryInfix', [left, right], op]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -84,10 +84,6 @@ def var_decl(typen, var):
     return [typen, var]
 
 
-def dummy(*args):
-    return ['Dummy', args]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -506,7 +502,7 @@ class JSONWriter:
                 return self.literal_double(op.cst)
             elif op.type == 'Ljava/lang/Class;':
                 return self.literal_class(op.clsdesc)
-            return dummy('??? Unexpected constant: ' + str(op.type))
+            return self.dummy('??? Unexpected constant: ' + str(op.type))
 
         if isinstance(op, instruction.FillArrayExpression):
             array_expr = self.visit_expr(op.var_map[op.reg])
@@ -543,9 +539,9 @@ class JSONWriter:
             return method_invocation(op.triple, op.name, self.visit_expr(base), params)
         # for unmatched monitor instructions, just create dummy expressions
         if isinstance(op, instruction.MonitorEnterExpression):
-            return dummy("monitor enter(", self.visit_expr(op.var_map[op.ref]), ")")
+            return self.dummy("monitor enter(", self.visit_expr(op.var_map[op.ref]), ")")
         if isinstance(op, instruction.MonitorExitExpression):
-            return dummy("monitor exit(", self.visit_expr(op.var_map[op.ref]), ")")
+            return self.dummy("monitor exit(", self.visit_expr(op.var_map[op.ref]), ")")
         if isinstance(op, instruction.MoveExpression):
             lhs = op.var_map.get(op.lhs)
             rhs = op.var_map.get(op.rhs)
@@ -560,7 +556,7 @@ class JSONWriter:
             return array_creation(tn, [expr], 1)
         # create dummy expression for unmatched newinstance
         if isinstance(op, instruction.NewInstance):
-            return dummy("new ", self.parse_descriptor(op.type))
+            return self.dummy("new ", self.parse_descriptor(op.type))
         if isinstance(op, instruction.Param):
             if isinstance(op, instruction.ThisParam):
                 return local('this')
@@ -585,7 +581,7 @@ class JSONWriter:
         if isinstance(op, instruction.Variable):
             # assert(op.declared)
             return local('v{}'.format(op.name))
-        return dummy('??? Unexpected op: ' + type(op).__name__)
+        return self.dummy('??? Unexpected op: ' + type(op).__name__)
 
     def visit_arr_data(self, value):
         data = value.get_data()
@@ -652,7 +648,7 @@ class JSONWriter:
         if desc and desc[0] == 'L' and desc[-1] == ';':
             return typen(desc[1:-1], dim)
         # invalid descriptor (probably None)
-        return dummy(str(desc))
+        return JSONWriter.dummy(str(desc))
 
     @staticmethod
     def _append(sb, stmt):
@@ -703,3 +699,7 @@ class JSONWriter:
     @staticmethod
     def expression_stmt(expr):
         return ['ExpressionStatement', expr]
+
+    @staticmethod
+    def dummy(*args):
+        return ['Dummy', args]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -99,10 +99,6 @@ def local_decl_stmt(expr, decl):
     return ['LocalDeclarationStatement', expr, decl]
 
 
-def return_stmt(expr):
-    return ['ReturnStatement', expr]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -405,7 +401,7 @@ class JSONWriter:
     def _visit_ins(self, op, isCtor=False):
         if isinstance(op, instruction.ReturnInstruction):
             expr = None if op.arg is None else self.visit_expr(op.var_map[op.arg])
-            return return_stmt(expr)
+            return self.return_stmt(expr)
         elif isinstance(op, instruction.ThrowExpression):
             return self.throw_stmt(self.visit_expr(op.var_map[op.ref]))
         elif isinstance(op, instruction.NopExpression):
@@ -706,3 +702,7 @@ class JSONWriter:
     @staticmethod
     def throw_stmt(expr):
         return ['ThrowStatement', expr]
+
+    @staticmethod
+    def return_stmt(expr):
+        return ['ReturnStatement', expr]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -128,12 +128,6 @@ def switch_stmt(cond_expr, ksv_pairs):
     return ['SwitchStatement', None, cond_expr, ksv_pairs]
 
 
-# Create empty statement block (statements to be appended later)
-# Note, the code below assumes this can be modified in place
-def statement_block():
-    return ['BlockStatement', None, []]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -157,7 +151,7 @@ class JSONWriter:
     # which pushes a statement block on to the context stack and assigns it to foo
     # within the with block, all added instructions will be added to foo
     def __enter__(self):
-        self.context.append(statement_block())
+        self.context.append(self.statement_block())
         return self.context[-1]
 
     def __exit__(self, *args):
@@ -706,3 +700,9 @@ class JSONWriter:
         assert (sb[0] == 'BlockStatement')
         if stmt is not None:
             sb[2].append(stmt)
+
+    @staticmethod
+    def statement_block():
+        # Create empty statement block (statements to be appended later)
+        # Note, the code below assumes this can be modified in place
+        return ['BlockStatement', None, []]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -111,11 +111,6 @@ def jump_stmt(keyword):
     return ['JumpStatement', keyword, None]
 
 
-def loop_stmt(isdo, cond_expr, body):
-    type_ = 'DoStatement' if isdo else 'WhileStatement'
-    return [type_, None, cond_expr, body]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -261,7 +256,7 @@ class JSONWriter:
                 self.visit_node(loop.latch)
 
         assert (cond_expr is not None and isDo is not None)
-        self.add(loop_stmt(isDo, cond_expr, body))
+        self.add(self.loop_stmt(isDo, cond_expr, body))
         if follow is not None:
             self.visit_node(follow)
 
@@ -706,3 +701,8 @@ class JSONWriter:
     @staticmethod
     def try_stmt(tryb, pairs):
         return ['TryStatement', None, tryb, pairs]
+
+    @staticmethod
+    def loop_stmt(isdo, cond_expr, body):
+        type_ = 'DoStatement' if isdo else 'WhileStatement'
+        return [type_, None, cond_expr, body]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -50,10 +50,6 @@ def field_access(triple, left):
     return ['FieldAccess', [left], triple]
 
 
-def literal(result, tt):
-    return ['Literal', result, tt]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -572,39 +568,39 @@ class JSONWriter:
 
     @staticmethod
     def literal_null():
-        return literal('null', ('.null', 0))
+        return JSONWriter.literal('null', ('.null', 0))
 
     @staticmethod
     def literal_double(f):
-        return literal(str(f), ('.double', 0))
+        return JSONWriter.literal(str(f), ('.double', 0))
 
     @staticmethod
     def literal_float(f):
-        return literal(str(f) + 'f', ('.float', 0))
+        return JSONWriter.literal(str(f) + 'f', ('.float', 0))
 
     @staticmethod
     def literal_long(b):
-        return literal(str(b) + 'L', ('.long', 0))
+        return JSONWriter.literal(str(b) + 'L', ('.long', 0))
 
     @staticmethod
     def literal_hex_int(b):
-        return literal(hex(b), ('.int', 0))
+        return JSONWriter.literal(hex(b), ('.int', 0))
 
     @staticmethod
     def literal_int(b):
-        return literal(str(b), ('.int', 0))
+        return JSONWriter.literal(str(b), ('.int', 0))
 
     @staticmethod
     def literal_bool(b):
-        return literal(str(b).lower(), ('.boolean', 0))
+        return JSONWriter.literal(str(b).lower(), ('.boolean', 0))
 
     @staticmethod
     def literal_class(desc):
-        return literal(JSONWriter.parse_descriptor(desc), ('java/lang/Class', 0))
+        return JSONWriter.literal(JSONWriter.parse_descriptor(desc), ('java/lang/Class', 0))
 
     @staticmethod
     def literal_string(s):
-        return literal(str(s), ('java/lang/String', 0))
+        return JSONWriter.literal(str(s), ('java/lang/String', 0))
 
     @staticmethod
     def parse_descriptor(desc: str) -> list:
@@ -703,3 +699,7 @@ class JSONWriter:
     @staticmethod
     def local(name):
         return ['Local', name]
+
+    @staticmethod
+    def literal(result, tt):
+        return ['Literal', result, tt]

--- a/androguard/decompiler/dast.py
+++ b/androguard/decompiler/dast.py
@@ -116,10 +116,6 @@ def loop_stmt(isdo, cond_expr, body):
     return [type_, None, cond_expr, body]
 
 
-def try_stmt(tryb, pairs):
-    return ['TryStatement', None, tryb, pairs]
-
-
 class JSONWriter:
     def __init__(self, graph, method):
         self.graph = graph
@@ -407,7 +403,7 @@ class JSONWriter:
                 self.visit_node(catch_node.catch_start)
             pairs.append((catch_decl, body))
 
-        self.add(try_stmt(tryb, pairs))
+        self.add(self.try_stmt(tryb, pairs))
         self.visit_node(self.try_follow.pop())
 
     def visit_return_node(self, ret):
@@ -706,3 +702,7 @@ class JSONWriter:
     @staticmethod
     def if_stmt(cond_expr, scopes):
         return ['IfStatement', None, cond_expr, scopes]
+
+    @staticmethod
+    def try_stmt(tryb, pairs):
+        return ['TryStatement', None, tryb, pairs]

--- a/androguard/decompiler/decompile.py
+++ b/androguard/decompiler/decompile.py
@@ -39,7 +39,6 @@ from androguard.decompiler.dast import (
     JSONWriter,
     parse_descriptor,
     literal_string,
-    literal_hex_int,
     dummy
 )
 from androguard.decompiler.dataflow import (
@@ -69,7 +68,7 @@ def get_field_ast(field: EncodedField) -> dict:
             if field.get_descriptor() == 'Ljava/lang/String;':
                 expr = literal_string(val)
             elif field.proto == 'B':
-                expr = literal_hex_int(struct.unpack('<b', struct.pack("B", val))[0])
+                expr = JSONWriter.literal_hex_int(struct.unpack('<b', struct.pack("B", val))[0])
 
     return {
         'triple': triple,

--- a/androguard/decompiler/decompile.py
+++ b/androguard/decompiler/decompile.py
@@ -35,10 +35,7 @@ import androguard.decompiler.util as util
 from androguard.core.analysis import analysis
 from androguard.core import apk, dex
 from androguard.decompiler.control_flow import identify_structures
-from androguard.decompiler.dast import (
-    JSONWriter,
-    dummy
-)
+from androguard.decompiler.dast import JSONWriter
 from androguard.decompiler.dataflow import (
     build_def_use,
     place_declarations,
@@ -60,7 +57,7 @@ def get_field_ast(field: EncodedField) -> dict:
     expr = None
     if field.init_value:
         val = field.init_value.value
-        expr = dummy(str(val))
+        expr = JSONWriter.dummy(str(val))
 
         if val is not None:
             if field.get_descriptor() == 'Ljava/lang/String;':

--- a/androguard/decompiler/decompile.py
+++ b/androguard/decompiler/decompile.py
@@ -37,7 +37,6 @@ from androguard.core import apk, dex
 from androguard.decompiler.control_flow import identify_structures
 from androguard.decompiler.dast import (
     JSONWriter,
-    parse_descriptor,
     dummy
 )
 from androguard.decompiler.dataflow import (
@@ -71,7 +70,7 @@ def get_field_ast(field: EncodedField) -> dict:
 
     return {
         'triple': triple,
-        'type': parse_descriptor(field.get_descriptor()),
+        'type': JSONWriter.parse_descriptor(field.get_descriptor()),
         'flags': util.get_access_field(field.get_access_flags()),
         'expr': expr,
     }
@@ -312,11 +311,11 @@ class DvClass:
         isInterface = 'interface' in self.access
         return {
             'rawname': self.thisclass[1:-1],
-            'name': parse_descriptor(self.thisclass),
-            'super': parse_descriptor(self.superclass),
+            'name': JSONWriter.parse_descriptor(self.thisclass),
+            'super': JSONWriter.parse_descriptor(self.superclass),
             'flags': self.access,
             'isInterface': isInterface,
-            'interfaces': list(map(parse_descriptor, self.interfaces)),
+            'interfaces': list(map(JSONWriter.parse_descriptor, self.interfaces)),
             'fields': fields,
             'methods': methods,
         }

--- a/androguard/decompiler/decompile.py
+++ b/androguard/decompiler/decompile.py
@@ -38,7 +38,6 @@ from androguard.decompiler.control_flow import identify_structures
 from androguard.decompiler.dast import (
     JSONWriter,
     parse_descriptor,
-    literal_string,
     dummy
 )
 from androguard.decompiler.dataflow import (
@@ -66,7 +65,7 @@ def get_field_ast(field: EncodedField) -> dict:
 
         if val is not None:
             if field.get_descriptor() == 'Ljava/lang/String;':
-                expr = literal_string(val)
+                expr = JSONWriter.literal_string(val)
             elif field.proto == 'B':
                 expr = JSONWriter.literal_hex_int(struct.unpack('<b', struct.pack("B", val))[0])
 


### PR DESCRIPTION
## What does the PR do?

Converts functions in `androguard.decompiler.dast` into instance or static methods without changing their behaviour in any way. The modifications are supposed to be cosmetic and were carefully reviewed not to affect any existing functionality. Every change was introduced in a separate commit to make reviewing easier, but feel free to squash them.

## Rationale

With the previous version of the code it was difficult to alter the functionality of the `JSONWriter` class.

For some methods in `JSONWriter`, expanding the behaviour in a subclass would require re-implementing entire code blocks or using monkey patching.

Please take a look at the following example:

In the original version of the code the `androguard.decompiler.dast` module contains a function called `method_invocation`. It is used in another function called `visit_expr`. `visit_expr` is called by `JSONWriter` in `get_cond` and `visit_switch_node` instance methods.

If a developer wanted to add extra logic for cases when `JSONWriter` detects a method invocation (e.g. to dynamically log callers), the procedure would be very complicated:

1. Use some form of monkey patching to modify the `method_invocation` and `visit_expr` functions.
2. Override `get_cond` and `visit_switch_node` methods in a way that ensures the new versions of `method_invocation` and `visit_expr` are called.

If `method_invocation` is a method inside `JSONWriter`, the procedure is much simpler - the developer only needs to override `method_invocation` in a subclass.
