### PR TITLE
Fix empty `end` in interval nodes

### DIFF
--- a/androguard/decompiler/node.py
+++ b/androguard/decompiler/node.py
@@ -147,6 +147,7 @@ class Interval:
             for suc in graph.sucs(node):
                 if suc not in self.content:
                     self.end = node
+        self.end = self.end or self.head
 
     def get_end(self):
         return self.end.get_end()


### PR DESCRIPTION
Possible fix for #1081. More details available in the issue.
