### PR TITLE
fix: Ensure _analyse is called before accessing resource_keys object.

### DIFF
--- a/androguard/core/axml/__init__.py
+++ b/androguard/core/axml/__init__.py
@@ -2612,7 +2612,8 @@ class ARSCParser:
         except KeyError:
             return None
 
-    def get_res_id_by_key(self, package_name, resource_type, key):
+    def get_res_id_by_key(self, package_name: str, resource_type: str, key: str) -> Union[int, None]:
+        self._analyse()
         try:
             return self.resource_keys[package_name][resource_type][key]
         except KeyError:

--- a/tests/test_arsc.py
+++ b/tests/test_arsc.py
@@ -11,6 +11,7 @@ from operator import itemgetter
 from androguard.core import apk, axml
 
 TEST_APP_NAME = "TestsAndroguardApplication"
+TEST_PACKAGE_NAME = "tests.androguard"
 TEST_ICONS = {
     120: "res/drawable-ldpi/icon.png",
     160: "res/drawable-mdpi/icon.png",
@@ -47,6 +48,18 @@ class ARSCTest(unittest.TestCase):
             TEST_APP_NAME,
             "Couldn't deduce application/activity label",
         )
+
+    def testGetResIdByKey(self):
+        arsc = self.apk.get_android_resources()
+        expected_id = 2130968577
+
+        app_name_res_id = arsc.get_res_id_by_key(
+            TEST_PACKAGE_NAME,
+            "string",
+            "app_name"
+        )
+
+        self.assertEqual(app_name_res_id, expected_id)
 
     def testAppIcon(self):
         for wanted_density, correct_path in TEST_ICONS.items():


### PR DESCRIPTION
## Fix missing `_analyse()` call in `get_res_id_by_key` and add unit test

### Description  
This PR fixes an issue in `get_res_id_by_key` where `self._analyse()` was missing. Without this call, `self.resource_keys` remains uninitialized, always resulting in a `KeyError`. The fix ensures that `_analyse()` is invoked before accessing `self.resource_keys`.  

### Changes  
- Added `self._analyse()` at the beginning of `get_res_id_by_key`.
- Added type annotations for `get_res_id_by_key`.
- Added a unit test for `get_res_id_by_key`.