### PR TITLE
fix for https://github.com/androguard/androguard/issues/1102

### DIFF
--- a/androguard/core/axml/__init__.py
+++ b/androguard/core/axml/__init__.py
@@ -2961,7 +2961,8 @@ class ARSCResType:
         (self.flags,) = unpack('<B', buff.read(1))
         self.reserved = unpack('<H', buff.read(2))[0]
         if self.reserved != 0:
-            raise ResParserError("reserved must be zero!")
+            # /libs/androidfw/LoadedArsc.cpp -> VerifyResTableType does not verify reserved value!
+            logger.warning("Reserved must be zero! Meta is that you?")
         self.entryCount = unpack('<I', buff.read(4))[0]
         self.entriesStart = unpack('<I', buff.read(4))[0]
 


### PR DESCRIPTION
[This](https://android.googlesource.com/platform/frameworks/base/+/master/libs/androidfw/include/androidfw/ResourceTypes.h#1478) should have been a reserved value, but Meta seems for some weird reason to be assigning values to it. Android itself can process it regardless as the validation [here](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/libs/androidfw/LoadedArsc.cpp#80) does not validate the reserved value.

Therefore I have changed the respective code to no longer raise an error but to log a warning.