### PR TITLE
Fix: normalize protectionLevel parsing in get_details_permissions

### DIFF
--- a/androguard/core/apk/__init__.py
+++ b/androguard/core/apk/__init__.py
@@ -1538,12 +1538,20 @@ class APK:
                 x = self.permission_module[i]
                 l[i] = [x["protectionLevel"], x["label"], x["description"]]
             elif i in self.declared_permissions:
-                protectionLevel_hex = self.declared_permissions[i][
-                    "protectionLevel"
-                ]
-                protectionLevel = protection_flags_to_attributes[
-                    protectionLevel_hex
-                ]
+                protectionLevel_hex = self.declared_permissions[i]["protectionLevel"]
+                try:
+                    key = int(protectionLevel_hex, 0) if isinstance(protectionLevel_hex, str) else protectionLevel_hex
+                except Exception:
+                    key = None
+
+                protectionLevel = protection_flags_to_attributes.get(key) if isinstance(key, int) else None
+                if protectionLevel is None:
+                    protectionLevel = protection_flags_to_attributes.get(protectionLevel_hex)
+                if protectionLevel is None and isinstance(key, int):
+                    protectionLevel = protection_flags_to_attributes.get(key & 0xF)
+                if protectionLevel is None:
+                    protectionLevel = f"unknown({protectionLevel_hex!r})"
+
                 l[i] = [
                     protectionLevel,
                     "Unknown permission from android reference",


### PR DESCRIPTION
Some APKs declare permissions with protectionLevel attributes like "0x00000012" (Example `com.samsung.android.bixby.agent, sha256:7ca732b17adbe87f54a0b7fe904bc5fee825028ea88464b5bfa9c716e562de47`) . In current code these values are stored as strings, causing KeyError when looked up in protection_flags_to_attributes (which uses int keys).

This patch normalizes "0x..." strings to int and falls back to the base protection level (low 4 bits) if a combined flag is not mapped.