### PR TITLE
Fix: add support for `FLAG_SPARSE` and fix resource resolution in `compact entries`

### DIFF
--- a/androguard/core/axml/__init__.py
+++ b/androguard/core/axml/__init__.py
@@ -3595,11 +3595,14 @@ class ARSCResTableEntry:
         return self.index
 
     def get_value(self) -> str:
-        return self.parent.mKeyStrings.getString(self.index)
+        if self.is_compact():
+            return self.parent.mKeyStrings.getString(self.key)
+        else:
+            return self.parent.mKeyStrings.getString(self.index)
 
     def get_key_data(self) -> str:
         if self.is_compact():
-            return self.parent.stringpool_main.getString(self.key)
+            return self.parent.stringpool_main.getString(self.data)
         else:
             return self.key.get_data_value()
 


### PR DESCRIPTION
When attempting to parse `framework-res.apk` resources built for Android 15, the following error occurs:

```
Traceback (most recent call last):
  File "/<REDACTED>/.venv/lib/python3.13/site-packages/androguard/core/apk/__init__.py", line 2210, in get_android_resources
    return self.arsc["resources.arsc"]
           ~~~~~~~~~^^^^^^^^^^^^^^^^^^
KeyError: 'resources.arsc'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/<REDACTED>/poc.py", line 4, in <module>
    a.get_android_resources()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/<REDACTED>/.venv/lib/python3.13/site-packages/androguard/core/apk/__init__.py", line 2216, in get_android_resources
    self.arsc["resources.arsc"] = ARSCParser(
                                  ~~~~~~~~~~^
        self.zip.read("resources.arsc")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/<REDACTED>/.venv/lib/python3.13/site-packages/androguard/core/axml/__init__.py", line 1880, in __init__
    ate = ARSCResTableEntry(
        self.buff,
    ...<3 lines>...
        pc,
    )
  File "/<REDACTED>/.venv/lib/python3.13/site-packages/androguard/core/axml/__init__.py", line 3565, in __init__
    self.size = unpack('<H', buff.read(2))[0]
                ~~~~~~^^^^^^^^^^^^^^^^^^^^
struct.error: unpack requires a buffer of 2 bytes
```

The issue originates from this piece of [code](https://github.com/androguard/androguard/blob/9d1339f88098f319372746b9d631bdb22aaa6fad/androguard/core/axml/__init__.py#L1858):

```python
if a_res_type.flags & FLAG_OFFSET16:
    # Read as 16-bit offset
    offset_16 = unpack('<H', self.buff.read(2))[0]
    offset = offset_from16(offset_16)
    if offset == NO_ENTRY_16:
        continue
else:
    # Read as 32-bit offset
    offset = unpack('<I', self.buff.read(4))[0]
    if offset == NO_ENTRY_32:
        continue
```

When a resource type entry has the `FLAG_SPARSE` flag set, `if a_res_type.flags & FLAG_OFFSET16` condition is not satisfied, and execution falls into the `else branch`. This lacks an additional check for a zeroed `flags` field (in case of 32-bit offsets).

As a result, [ResTable_sparseTypeEntry](https://android.googlesource.com/platform/frameworks/base/+/master/libs/androidfw/include/androidfw/ResourceTypes.h#1507) structures are misinterpreted as 32-bit offsets, leading to undefined behavior [here](https://github.com/androguard/androguard/blob/9d1339f88098f319372746b9d631bdb22aaa6fad/androguard/core/axml/__init__.py#L3562): the resulting offset may become excessively large, and a subsequent `seek` call may cause the buffer pointer to move outside valid bounds.

This pull request introduces an implementation of `FLAG_SPARSE` support.  Additionally, some bugs were fixed where `value` and `key_data` were incorrectly [resolved](https://github.com/androguard/androguard/blob/9d1339f88098f319372746b9d631bdb22aaa6fad/androguard/core/axml/__init__.py#L3588) in case of `compact resource entries`. 