### PR TITLE
fix wrong arg-reg mapping of MethodAnalysis.show()

### DIFF
--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -776,9 +776,9 @@ class MethodAnalysis:
             start_reg = reg_len - nb_args
             for i, a in enumerate(args):
                 if a in ("D", "J"):
-                    args[i] = "{} v{}..v{}".format(a, start_reg, start_reg + 1)
+                    args[i] = f"{a} v{start_reg}..v{start_reg + 1}"
                 else:
-                    args[i] = "{} v{}".format(a, start_reg)
+                    args[i] = f"{a} v{start_reg}"
                 start_reg += arg_sizes[i]
 
         print(


### PR DESCRIPTION
`long` and `double` need 2 regs to represent.

before fix:
```
METHOD Lcom/samsung/android/rapidmomentengine/engines/EngineFaceProcessor$a; private static j (D v6, D v7)I
j-BB@0x0 :
        0  (00000000) const-wide          v0, 4636033603912859648
        0  (0000000a) div-double/2addr    v4, v0
        0  (0000000c) div-double/2addr    v6, v0
        0  (0000000e) invoke-static       v4, v5, Ljava/lang/Math;->abs(D)D
        0  (00000014) move-result-wide    v0
        0  (00000016) invoke-static       v6, v7, Ljava/lang/Math;->abs(D)D
```

after fix:
```
METHOD Lcom/samsung/android/rapidmomentengine/engines/EngineFaceProcessor$a; private static j (D v4..v5, D v6..v7)I
j-BB@0x0 :
        0  (00000000) const-wide          v0, 4636033603912859648
        0  (0000000a) div-double/2addr    v4, v0
        0  (0000000c) div-double/2addr    v6, v0
        0  (0000000e) invoke-static       v4, v5, Ljava/lang/Math;->abs(D)D
        0  (00000014) move-result-wide    v0
        0  (00000016) invoke-static       v6, v7, Ljava/lang/Math;->abs(D)D
```