### PR TITLE
fix-EncodedMethod: fix param-register mapping

### DIFF
--- a/androguard/core/dex/__init__.py
+++ b/androguard/core/dex/__init__.py
@@ -3274,11 +3274,16 @@ class EncodedMethod:
             info["return"] = get_type(ret[1])
 
             if params:
-                info["registers"] = (0, nb - len(params) - 1)
+                param_sizes = [
+                    2 if param in ("D", "J") else 1 for param in params
+                ]
+                info["registers"] = (0, nb - sum(param_sizes) - 1)
                 j = 0
                 info["params"] = []
-                for i in range(nb - len(params), nb):
+                i = nb - sum(param_sizes)
+                while i < nb:
                     info["params"].append((i, get_type(params[j])))
+                    i += param_sizes[j]
                     j += 1
             else:
                 info["registers"] = (0, nb - 1)


### PR DESCRIPTION
see https://github.com/androguard/androguard/pull/1143#issue-3570727943

for the method `public e ([B v5, I v6, I v7, I v8, I v9, I v10, J v11..v12)I`

- before fix:
{'return': 'int', 'registers': (0, 5), 'params': [(6, 'byte[]'), (7, 'int'), (8, 'int'), (9, 'int'), (10, 'int'), (11, 'int'), (12, 'long')]}
- after fix:
{'return': 'int', 'registers': (0, 4), 'params': [(5, 'byte[]'), (6, 'int'), (7, 'int'), (8, 'int'), (9, 'int'), (10, 'int'), (11, 'long')]}

for the method `private b (J v1..v2, J v3..v4, J v5..v6)J`
- before fix:
{'return': 'long', 'registers': (0, 3), 'params': [(4, 'long'), (5, 'long'), (6, 'long')]}
- after fix:
{'return': 'long', 'registers': (0, 0), 'params': [(1, 'long'), (3, 'long'), (5, 'long')]}

I'm not sure how to represent a param that takes two registers. So i use the first register of the two to represent it, cuz `*-wide` instructions usually operate the first register explicitly.