### PR TITLE
fix #1148

### DIFF
--- a/androguard/core/apk/__init__.py
+++ b/androguard/core/apk/__init__.py
@@ -993,7 +993,20 @@ class APK:
         :returns: the names of all DEX files found in the APK
         """
         dexre = re.compile(r"^classes(\d*).dex$")
-        return filter(lambda x: dexre.match(x), self.get_files())
+        dex_names = list(filter(
+            lambda x: (
+                dexre.match(x) and 
+                # classes0\d*.dex are not official dex files
+                not x.startswith("classes0") and 
+                # classes1.dex it not an official dex file
+                x != "classes1.dex"
+            ),
+            self.get_files()
+        ))
+        dex_names.sort(
+            key=lambda x: 0 if x == "classes.dex" else int(dexre.match(x).group(1)) - 1
+        )
+        return dex_names
 
     def get_all_dex(self) -> Iterator[bytes]:
         """


### PR DESCRIPTION
This should fix #1148 

I choose to filter and sort the output of APK.get_dex_names() to match [AOSP source code](https://cs.android.com/android/platform/superproject/main/+/main:art/libdexfile/dex/dex_file_loader.cc;l=145;drc=0ed0b7d7b2b71bf94d6dc02b59695a2dcaeb7181), and ignore classes already present in Analyze in Analyze.add().

This may not be the most robust solution: it assumes that Analyze.add() is called on dexfiles in the right order (which now is the case in AnalyzeAPK() with APK.get_dex_names()  sorted).
A better solution would be to compare the dexfile name of the class implementation already in the Analyze to the one of the new class implementation, and remove the previous implementation if it needs to be overridden, but I'm not sure of the side effects of removing a class already added.