### PR TITLE
fix-Analysis: now follow the type of add_xref_read

### DIFF
--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -136,8 +136,8 @@ class BasicBlocks:
         """
         return self.bb.pop(idx)
 
-    def get_basic_block(self, idx: int) -> Union[DEXBasicBlock,None]:
-        """return the [DEXBasicBlock][androguard.core.analysis.analysis.DEXBasicBlock] at `idx` 
+    def get_basic_block(self, idx: int) -> Union[DEXBasicBlock, None]:
+        """return the [DEXBasicBlock][androguard.core.analysis.analysis.DEXBasicBlock] at `idx`
 
         :param idx: the index of the `DEXBasicBlock` to return
         :return: the `DEXBasicBlock` or `None` if not found
@@ -373,6 +373,7 @@ class MethodAnalysis:
     It is a wrapper around a [androguard.core.dex.EncodedMethod][] and enhances it
     by using multiple [DEXBasicBlock][androguard.core.analysis.analysis.DEXBasicBlock] encapsulated in a [BasicBlocks][androguard.core.analysis.analysis.BasicBlocks] object.
     """
+
     def __init__(self, vm: dex.DEX, method: dex.EncodedMethod) -> None:
         """Initialize new [MethodAnalysis][androguard.core.analysis.analysis.MethodAnalysis]
 
@@ -420,7 +421,7 @@ class MethodAnalysis:
     @property
     def name(self) -> str:
         """Returns the name of this method
-        
+
         :returns: the name
         """
         return self.method.get_name()
@@ -428,7 +429,7 @@ class MethodAnalysis:
     @property
     def descriptor(self) -> str:
         """Returns the type descriptor for this method
-        
+
         :returns: the type descriptor
         """
         return self.method.get_descriptor()
@@ -436,7 +437,7 @@ class MethodAnalysis:
     @property
     def access(self) -> str:
         """Returns the access flags to the method as a string
-        
+
         :returns: the access flags
         """
         return self.method.get_access_flags_string()
@@ -444,7 +445,7 @@ class MethodAnalysis:
     @property
     def class_name(self) -> str:
         """Returns the name of the class of this method
-        
+
         :returns: the name of the class
         """
         return self.method.class_name
@@ -452,21 +453,21 @@ class MethodAnalysis:
     @property
     def full_name(self) -> str:
         """Returns classname + name + descriptor, separated by spaces (no access flags)
-        
+
         :returns: the method full name
         """
         return self.method.full_name
 
     def get_class_name(self) -> str:
         """Return the class name of the method
-        
+
         :returns: the name of the class
         """
         return self.class_name
 
     def get_access_flags_string(self) -> str:
         """Returns the concatenated access flags string
-        
+
         :returns: the access flags
         """
         return self.access
@@ -1097,7 +1098,7 @@ class ExternalMethod:
     @property
     def full_name(self) -> str:
         """Returns classname + name + descriptor, separated by spaces (no access flags)'
-        
+
         :returns: the formatted name
         """
         return (
@@ -1111,7 +1112,7 @@ class ExternalMethod:
     @property
     def permission_api_name(self) -> str:
         """Returns a name which can be used to look up in the permission maps
-        
+
         :returns: the formatted name
         """
         return (
@@ -1470,7 +1471,7 @@ class ClassAnalysis:
         the second one is the method in which the class is called ([MethodAnalysis][androguard.core.analysis.analysis.MethodAnalysis])
         and the third the offset in the method where the call is originating.
 
-        Examples: 
+        Examples:
 
             >>> # dx is an Analysis object
             for cls in dx.find_classes('.*some/name.*'):
@@ -1649,11 +1650,11 @@ class Analysis:
     XREFs are created for:
 
     * classes ([ClassAnalysis][androguard.core.analysis.analysis.ClassAnalysis])
-    
+
     * methods ([MethodAnalysis][androguard.core.analysis.analysis.MethodAnalysis])
-    
+
     * strings ([StringAnalysis][androguard.core.analysis.analysis.StringAnalysis])
-    
+
     * fields ([FieldAnalysis][androguard.core.analysis.analysis.FieldAnalysis])
 
     The Analysis should be the only object you are using next to the [APK][androguard.core.apk.APK].
@@ -1664,7 +1665,7 @@ class Analysis:
 
     def __init__(self, vm: Union[dex.DEX, None] = None) -> None:
         """Initialize a new [Analysis][androguard.core.analysis.analysis.Analysis] object
-        
+
         :param vm: inital DEX object (default None)
         """
         # Contains DEX objects
@@ -1687,7 +1688,7 @@ class Analysis:
     @property
     def fields(self) -> Iterator[FieldAnalysis]:
         """Returns [FieldAnalysis][androguard.core.analysis.analysis.FieldAnalysis] generator of this `Analysis`
-        
+
         :returns: iterator of `FieldAnalysis` objects
         """
         return self.get_fields()
@@ -1937,6 +1938,9 @@ class Analysis:
                             field_info[0], field_info[2], field_info[1]
                         )
                     )
+                    if not field_item:
+                        continue
+                    field_item = self.get_field_analysis(field_item)
                     if not field_item:
                         continue
 
@@ -2423,7 +2427,7 @@ class Analysis:
 
         The following example shows the usage and how to get the calling methods using XREF:
 
-        Examples: 
+        Examples:
 
             >>> from androguard.misc import AnalyzeAPK
             >>> a, d, dx = AnalyzeAPK("somefile.apk")


### PR DESCRIPTION
The caller of `MethodAnalysis.add_xref_read` passed `EncodedField` rather than `FieldAnalysis` it declares. As a result, `MethodAnalysis.get_xref_read` returned `EncodedField` rather than `FieldAnalysis` it declares.