### PR TITLE
Fix rtype of DEXBasicBlock.get_exception_analysis()

### DIFF
--- a/androguard/core/analysis/analysis.py
+++ b/androguard/core/analysis/analysis.py
@@ -350,7 +350,7 @@ class DEXBasicBlock:
         else:
             return None
 
-    def get_exception_analysis(self) -> ExceptionAnalysis:
+    def get_exception_analysis(self) -> Union[ExceptionAnalysis, None]:
         return self.exception_analysis
 
     def set_exception_analysis(self, exception_analysis: ExceptionAnalysis):


### PR DESCRIPTION
`self.exception_analysis` is `None` when there's no exception, e.g.:
```
createPageDataProvider-BB@0x0: 0000 - 0012
====================
createPageDataProvider-BB@0x12: 0012 - 0030
====================
12:2d
        (Ljava/lang/Exception; -> 30 createPageDataProvider-BB@0x30)
createPageDataProvider-BB@0x30: 0030 - 004e
====================
createPageDataProvider-BB@0x4e: 004e - 006c
====================
4e:69
        (Ljava/lang/Exception; -> 6c createPageDataProvider-BB@0x6c)
createPageDataProvider-BB@0x6c: 006c - 0098
```