### PR TITLE
Fix:  check worked incorrectly in case where chunk size equals chunk header size

### DIFF
--- a/androguard/core/axml/__init__.py
+++ b/androguard/core/axml/__init__.py
@@ -2820,7 +2820,7 @@ class ARSCHeader:
                 == cur_pos + self._header_size + 4 + 4
             ):
                 self._size = 24
-            header_ok = self._header_size >= self.SIZE and self._size > self.SIZE
+            header_ok = self._header_size >= self.SIZE and self._size >= self._header_size
             if (self._type < RES_XML_FIRST_CHUNK_TYPE or self._type > RES_XML_LAST_CHUNK_TYPE) and header_ok:
                 break
             if cur_pos == 0 or header_ok:


### PR DESCRIPTION
Issue occurs in `ARSCHeader` `__init__` function when it tries to parse `ResChunk_header` of `RES_XML_RESOURCE_MAP_TYPE` type chunk. At edge case when `_header_size == _size` `self._size > self.SIZE` condition becomes False so `header_ok` is False too. Parser handles it as `dummy data` and skips one byte. 

The same check done in `next` method of `ResChunkPullParser` (https://android.googlesource.com/platform/frameworks/base/+/4fafd67/tools/aapt2/ResChunkPullParser.cpp#56), but instead of strictly comparing chunk size with size of `ResChunk_header`, it compares it with `_header_size` and it allows `_size` to be equal `_header_size`